### PR TITLE
Add PVC bound check

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Cluster admin should create the following cluster-reader permissions for dedicat
 
 |Key|Description|Is Mandatory|Remarks|
 |---------------------------------------------|-------------------------------------------------------------------------------------------------------------------|--------------|-------------------------------------------------------------------------------------|
-|spec.timeout|How much time before the checkup will try to close itself|True||
+|spec.timeout|How much time before the checkup will try to close itself|False|Default is 10m|
+|spec.param.storageClass|Optional storage class to be used instead of the default one|False||
+|spec.param.vmiTimeout|Optional timeout for VMI operations|False|Default is 3m|
 
 ### Example
 
@@ -64,10 +66,11 @@ kubectl get configmap storage-checkup-config -n <target-namespace> -o yaml
 |status.result.defaultStorageClass|Indicates whether there is a default storage class||
 |status.result.pvcBound|PVC created and bound by the provisioner||
 |status.result.storageProfilesWithEmptyClaimPropertySets|StorageProfiles with empty claimPropertySets (unknown provisioners)||
-|status.result.storageProfilesWithSpecClaimPropertySets|StorageProfiles with spec-overrriden claimPropertySets||
+|status.result.storageProfilesWithSpecClaimPropertySets|StorageProfiles with spec-overriden claimPropertySets||
 |status.result.storageWithRWX|Storage with RWX access mode||
 |status.result.storageMissingVolumeSnapshotClass|Storage using snapshot-based clone but missing VolumeSnapshotClass||
 |status.result.goldenImagesNotUpToDate|Golden images whose DataImportCron is not up to date or DataSource is not ready||
+|status.result.goldenImagesNoDataSource|Golden images with no DataSource||
 |status.result.vmsWithNonVirtRbdStorageClass|VMs using the plain RBD storageclass when the virtualization storageclass exists||
 |status.result.vmsWithUnsetEfsStorageClass|VMs using an EFS storageclass where the gid and uid are not set in the storageclass||
 |status.result.vmBootFromGoldenImage|VM created and started from a golden image||

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ kubectl get configmap storage-checkup-config -n <target-namespace> -o yaml
 |status.startTimestamp|Checkup start timestamp|RFC 3339|
 |status.completionTimestamp|Checkup completion timestamp|RFC 3339|
 |status.result.defaultStorageClass|Indicates whether there is a default storage class||
+|status.result.pvcBound|PVC created and bound by the provisioner||
 |status.result.storageProfilesWithEmptyClaimPropertySets|StorageProfiles with empty claimPropertySets (unknown provisioners)||
 |status.result.storageProfilesWithSpecClaimPropertySets|StorageProfiles with spec-overrriden claimPropertySets||
 |status.result.storageWithRWX|Storage with RWX access mode||

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -39,7 +39,7 @@ const (
 func newVMUnderTest(name string, pvc *corev1.PersistentVolumeClaim, snap *snapshotv1.VolumeSnapshot,
 	checkupConfig config.Config) *kvcorev1.VirtualMachine {
 	optionsToApply := []vmi.Option{
-		vmi.WithDataVolume(rootDiskName, pvc, snap),
+		vmi.WithDataVolume(rootDiskName, pvc, snap, checkupConfig.StorageClass),
 		vmi.WithMemory(guestMemory),
 		vmi.WithTerminationGracePeriodSeconds(terminationGracePeriodSeconds),
 		vmi.WithOwnerReference(checkupConfig.PodName, checkupConfig.PodUID),

--- a/pkg/internal/checkup/vmi/spec.go
+++ b/pkg/internal/checkup/vmi/spec.go
@@ -60,7 +60,7 @@ func NewVM(name string, options ...Option) *kvcorev1.VirtualMachine {
 	return newVM
 }
 
-func WithDataVolume(volumeName string, pvc *corev1.PersistentVolumeClaim, snap *snapshotv1.VolumeSnapshot) Option {
+func WithDataVolume(volumeName string, pvc *corev1.PersistentVolumeClaim, snap *snapshotv1.VolumeSnapshot, storageClass string) Option {
 	return func(vm *kvcorev1.VirtualMachine) {
 		dvt := kvcorev1.DataVolumeTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
@@ -77,12 +77,17 @@ func WithDataVolume(volumeName string, pvc *corev1.PersistentVolumeClaim, snap *
 				Namespace: pvc.Namespace,
 				Name:      pvc.Name,
 			}
-			dvt.Spec.Storage.StorageClassName = pvc.Spec.StorageClassName
 		} else if snap != nil {
 			dvt.Spec.Source.Snapshot = &cdiv1.DataVolumeSourceSnapshot{
 				Namespace: snap.Namespace,
 				Name:      snap.Name,
 			}
+		}
+
+		if storageClass != "" {
+			dvt.Spec.Storage.StorageClassName = &storageClass
+		} else if pvc != nil {
+			dvt.Spec.Storage.StorageClassName = pvc.Spec.StorageClassName
 		}
 
 		vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, dvt)

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -31,6 +31,7 @@ const (
 	OCPVersionKey                                = "ocpVersion"
 	CNVVersionKey                                = "cnvVersion"
 	DefaultStorageClassKey                       = "defaultStorageClass"
+	PVCBoundKey                                  = "pvcBound"
 	StorageProfilesWithEmptyClaimPropertySetsKey = "storageProfilesWithEmptyClaimPropertySets"
 	StorageProfilesWithSpecClaimPropertySetsKey  = "storageProfilesWithSpecClaimPropertySets"
 	StorageWithRWXKey                            = "storageWithRWX"
@@ -77,6 +78,7 @@ func FormatResults(checkupResults status.Results) map[string]string {
 		OCPVersionKey:          checkupResults.OCPVersion,
 		CNVVersionKey:          checkupResults.CNVVersion,
 		DefaultStorageClassKey: checkupResults.DefaultStorageClass,
+		PVCBoundKey:            checkupResults.PVCBound,
 		StorageProfilesWithEmptyClaimPropertySetsKey: checkupResults.StorageProfilesWithEmptyClaimPropertySets,
 		StorageProfilesWithSpecClaimPropertySetsKey:  checkupResults.StorageProfilesWithSpecClaimPropertySets,
 		StorageWithRWXKey:                    checkupResults.StorageWithRWX,

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -68,6 +68,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			OCPVersion:          "1.2.3",
 			CNVVersion:          "4.5.6",
 			DefaultStorageClass: "test_sc",
+			PVCBound:            "ok",
 			StorageProfilesWithEmptyClaimPropertySets: "sc1, sc2",
 			StorageProfilesWithSpecClaimPropertySets:  "sc3, sc4",
 			StorageWithRWX:                            "sc5, sc6",
@@ -91,6 +92,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.result.ocpVersion":                                checkupStatus.Results.OCPVersion,
 			"status.result.cnvVersion":                                checkupStatus.Results.CNVVersion,
 			"status.result.defaultStorageClass":                       checkupStatus.Results.DefaultStorageClass,
+			"status.result.pvcBound":                                  checkupStatus.Results.PVCBound,
 			"status.result.storageProfilesWithEmptyClaimPropertySets": checkupStatus.Results.StorageProfilesWithEmptyClaimPropertySets,
 			"status.result.storageProfilesWithSpecClaimPropertySets":  checkupStatus.Results.StorageProfilesWithSpecClaimPropertySets,
 			"status.result.storageWithRWX":                            checkupStatus.Results.StorageWithRWX,
@@ -106,7 +108,6 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		}
 		assert.Equal(t, expectedReportData, getCheckupData(t, fakeClient, testNamespace, testConfigMapName))
 	})
-
 	t.Run("on checkup failure", func(t *testing.T) {
 		fakeClient := fake.NewSimpleClientset(newConfigMap())
 		testReporter := reporter.New(fakeClient, testNamespace, testConfigMapName)
@@ -125,7 +126,6 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.startTimestamp":      timestamp(checkupStatus.StartTimestamp),
 			"status.completionTimestamp": timestamp(checkupStatus.CompletionTimestamp),
 		}
-
 		assert.Equal(t, expectedReportData, getCheckupData(t, fakeClient, testNamespace, testConfigMapName))
 	})
 

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -27,6 +27,7 @@ type Results struct {
 	OCPVersion                                string
 	CNVVersion                                string
 	DefaultStorageClass                       string
+	PVCBound                                  string
 	StorageProfilesWithEmptyClaimPropertySets string
 	StorageProfilesWithSpecClaimPropertySets  string
 	StorageWithRWX                            string


### PR DESCRIPTION
Add a check that we can create a 20MiB PVC of the configured/default storage class and it will be bound by the provisioner.

Also add optional checkup params:
`spec.param.storageClass` - optional storage class to be used instead of the default one (needed for the new check).
`spec.param.vmiTimeout` - optional timeout for VMI operations (the default is 3min).
