### PR TITLE
Decrease bound check PVC size to 10Mi

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ kubectl get configmap storage-checkup-config -n <target-namespace> -o yaml
 |status.startTimestamp|Checkup start timestamp|RFC 3339|
 |status.completionTimestamp|Checkup completion timestamp|RFC 3339|
 |status.result.defaultStorageClass|Indicates whether there is a default storage class||
-|status.result.pvcBound|PVC created and bound by the provisioner||
+|status.result.pvcBound|PVC of 10Mi created and bound by the provisioner||
 |status.result.storageProfilesWithEmptyClaimPropertySets|StorageProfiles with empty claimPropertySets (unknown provisioners)||
 |status.result.storageProfilesWithSpecClaimPropertySets|StorageProfiles with spec-overriden claimPropertySets||
 |status.result.storageWithRWX|Storage with RWX access mode||

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -421,7 +421,7 @@ func (c *Checkup) checkPVCCreationAndBinding(ctx context.Context, errStr *string
 			Storage: &cdiv1.StorageSpec{
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("20Mi"),
+						corev1.ResourceStorage: resource.MustParse("10Mi"),
 					},
 				},
 			},
@@ -456,6 +456,7 @@ func (c *Checkup) waitForPVCBound(ctx context.Context, result, errStr *string) {
 
 	log.Printf("Waiting for PVC %q bound", pvcName)
 	if err := wait.PollImmediateWithContext(ctx, pollInterval, time.Minute, conditionFn); err != nil {
+		log.Printf("PVC %q failed to bound", pvcName)
 		appendSep(result, ErrPvcNotBound)
 		appendSep(errStr, ErrPvcNotBound)
 		return


### PR DESCRIPTION
We would like to check provisioners can create and bound a 10Mi PVC, as the kubevirt requirement for the "Backend state PVC" is 10Mi.