### PR TITLE
Add concurrent VM boot checkup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Cluster admin should create the following cluster-reader permissions for dedicat
 |spec.timeout|How much time before the checkup will try to close itself|False|Default is 10m|
 |spec.param.storageClass|Optional storage class to be used instead of the default one|False||
 |spec.param.vmiTimeout|Optional timeout for VMI operations|False|Default is 3m|
+|spec.param.numOfVMs|Optional number of concurrent VMs to boot|False|Default is 10|
 
 ### Example
 
@@ -63,6 +64,8 @@ kubectl get configmap storage-checkup-config -n <target-namespace> -o yaml
 |status.failureReason|Failure reason in case of a failure||
 |status.startTimestamp|Checkup start timestamp|RFC 3339|
 |status.completionTimestamp|Checkup completion timestamp|RFC 3339|
+|status.result.cnvVersion|OpenShift Virtualization version||
+|status.result.ocpVersion|OpenShift Container Platform cluster version||
 |status.result.defaultStorageClass|Indicates whether there is a default storage class||
 |status.result.pvcBound|PVC of 10Mi created and bound by the provisioner||
 |status.result.storageProfilesWithEmptyClaimPropertySets|StorageProfiles with empty claimPropertySets (unknown provisioners)||
@@ -78,3 +81,4 @@ kubectl get configmap storage-checkup-config -n <target-namespace> -o yaml
 |status.result.vmVolumeClone|VM volume clone type used (efficient or host-assisted) and fallback reason||
 |status.result.vmLiveMigration|VM live-migration||
 |status.result.vmHotplugVolume|VM volume hotplug and unplug||
+|status.result.concurrentVMBoot|Concurrent VM boot from a golden image||

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -1047,7 +1047,8 @@ func uniqueVMName() string {
 
 type checkVMIStatusFn func(*kvcorev1.VirtualMachineInstance) (done bool, err error)
 
-func (c *Checkup) waitForVMIStatus(ctx context.Context, vmName, checkMsg string, result, errStr *string, checkVMIStatus checkVMIStatusFn) error {
+func (c *Checkup) waitForVMIStatus(ctx context.Context, vmName, checkMsg string, result, errStr *string,
+	checkVMIStatus checkVMIStatusFn) error {
 	conditionFn := func(ctx context.Context) (bool, error) {
 		vmi, err := c.client.GetVirtualMachineInstance(ctx, c.namespace, vmName)
 		if err != nil {

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -124,13 +124,17 @@ func TestCheckupShouldReturnErrorWhen(t *testing.T) {
 		"dataSourceNotReady": {
 			clientConfig: clientConfig{dataSourceNotReady: true, expectNoVMI: true},
 			expectedResults: map[string]string{reporter.GoldenImagesNotUpToDateKey: testNamespace + "/" + testDIC,
-				reporter.VMBootFromGoldenImageKey: checkup.MessageSkipNoGoldenImage},
+				reporter.VMBootFromGoldenImageKey: checkup.MessageSkipNoGoldenImage,
+				reporter.ConcurrentVMBootKey:      checkup.MessageSkipNoGoldenImage,
+			},
 			expectedErr: checkup.ErrGoldenImagesNotUpToDate,
 		},
 		"dicNoDataSource": {
 			clientConfig: clientConfig{dicNoDataSource: true, expectNoVMI: true},
 			expectedResults: map[string]string{reporter.GoldenImagesNoDataSourceKey: testNamespace + "/" + testDIC,
-				reporter.VMBootFromGoldenImageKey: checkup.MessageSkipNoGoldenImage},
+				reporter.VMBootFromGoldenImageKey: checkup.MessageSkipNoGoldenImage,
+				reporter.ConcurrentVMBootKey:      checkup.MessageSkipNoGoldenImage,
+			},
 			expectedErr: checkup.ErrGoldenImageNoDataSource,
 		},
 		"vmisWithUnsetEfsSC": {
@@ -238,6 +242,7 @@ func successfulRunResults(vmiUnderTestName string) map[string]string {
 		reporter.VMLiveMigrationKey:                           fmt.Sprintf("VMI %q migration completed", vmiUnderTestName),
 		reporter.VMHotplugVolumeKey: fmt.Sprintf("VMI %q hotplug volume ready\nVMI %q hotplug volume removed",
 			vmiUnderTestName, vmiUnderTestName),
+		reporter.ConcurrentVMBootKey: "Boot completed on all VMs on time",
 	}
 }
 

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -45,6 +45,7 @@ const (
 	VMVolumeCloneKey                             = "vmVolumeClone"
 	VMLiveMigrationKey                           = "vmLiveMigration"
 	VMHotplugVolumeKey                           = "vmHotplugVolume"
+	ConcurrentVMBootKey                          = "concurrentVMBoot"
 )
 
 type Reporter struct {
@@ -93,6 +94,7 @@ func FormatResults(checkupResults status.Results) map[string]string {
 		VMVolumeCloneKey:                             checkupResults.VMVolumeClone,
 		VMLiveMigrationKey:                           checkupResults.VMLiveMigration,
 		VMHotplugVolumeKey:                           checkupResults.VMHotplugVolume,
+		ConcurrentVMBootKey:                          checkupResults.ConcurrentVMBoot,
 	}
 
 	return formattedResults

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -41,6 +41,8 @@ import (
 const (
 	testNamespace     = "target-ns"
 	testConfigMapName = "storage-checkup-config"
+	failureReason1    = "some reason"
+	failureReason2    = "some other reason"
 )
 
 func TestReportShouldSucceed(t *testing.T) {
@@ -51,11 +53,6 @@ func TestReportShouldSucceed(t *testing.T) {
 }
 
 func TestReportShouldSuccessfullyReportResults(t *testing.T) {
-	const (
-		failureReason1 = "some reason"
-		failureReason2 = "some other reason"
-	)
-
 	t.Run("on checkup success", func(t *testing.T) {
 		fakeClient := fake.NewSimpleClientset(newConfigMap())
 		testReporter := reporter.New(fakeClient, testNamespace, testConfigMapName)

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -81,6 +81,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			VMVolumeClone:                             "snapshot",
 			VMLiveMigration:                           "success",
 			VMHotplugVolume:                           "fail",
+			ConcurrentVMBoot:                          "ok",
 		}
 		assert.NoError(t, testReporter.Report(checkupStatus))
 
@@ -106,6 +107,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.result.vmVolumeClone":                             checkupStatus.Results.VMVolumeClone,
 			"status.result.vmLiveMigration":                           checkupStatus.Results.VMLiveMigration,
 			"status.result.vmHotplugVolume":                           checkupStatus.Results.VMHotplugVolume,
+			"status.result.concurrentVMBoot":                          checkupStatus.Results.ConcurrentVMBoot,
 		}
 		assert.Equal(t, expectedReportData, getCheckupData(t, fakeClient, testNamespace, testConfigMapName))
 	})

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -41,6 +41,7 @@ type Results struct {
 	VMVolumeClone                             string
 	VMLiveMigration                           string
 	VMHotplugVolume                           string
+	ConcurrentVMBoot                          string
 }
 
 type Status struct {


### PR DESCRIPTION
We would like to validate a CSI driver can handle parallelization, so we start 10 VMs simultaneously where each VM has one cloned boot disk and one empty data disk. The test passes if all VMs successfully boot. We allow setting the number of concurrent VMs to boot.

jira-ticket: https://issues.redhat.com/browse/CNV-44285