### PR TITLE
Fix checkup inconsistencies

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -847,6 +847,11 @@ func (c *Checkup) checkVMIBoot(ctx context.Context, errStr *string) error {
 		return err
 	}
 
+	if c.goldenImageSnap != nil {
+		c.results.VMVolumeClone = "DV cloneType: snapshot"
+		return nil
+	}
+
 	pvc, err := c.client.GetPersistentVolumeClaim(ctx, c.namespace, getVMDvName(vmName))
 	if err != nil {
 		return err

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -80,7 +80,8 @@ const (
 	VMIUnderTestNamePrefix = "vmi-under-test"
 	hotplugVolumeName      = "hotplug-volume"
 	pvcName                = "checkup-pvc"
-	strTrue                = "true"
+	StrTrue                = "true"
+	StrFalse               = "false"
 
 	AnnDefaultVirtStorageClass = "storageclass.kubevirt.io/is-default-virt-class"
 	AnnDefaultStorageClass     = "storageclass.kubernetes.io/is-default-class"
@@ -409,7 +410,7 @@ func (c *Checkup) checkDefaultStorageClass(scs *storagev1.StorageClassList, errS
 	var multipleDefaultStorageClasses, hasDefaultVirtStorageClass, hasDefaultStorageClass bool
 	for i := range scs.Items {
 		sc := scs.Items[i]
-		if sc.Annotations[AnnDefaultVirtStorageClass] == strTrue {
+		if sc.Annotations[AnnDefaultVirtStorageClass] == StrTrue {
 			if !hasDefaultVirtStorageClass {
 				hasDefaultVirtStorageClass = true
 				c.defaultStorageClass = sc.Name
@@ -417,7 +418,7 @@ func (c *Checkup) checkDefaultStorageClass(scs *storagev1.StorageClassList, errS
 				multipleDefaultStorageClasses = true
 			}
 		}
-		if sc.Annotations[AnnDefaultStorageClass] == strTrue {
+		if sc.Annotations[AnnDefaultStorageClass] == StrTrue {
 			if !hasDefaultStorageClass {
 				hasDefaultStorageClass = true
 				if !hasDefaultVirtStorageClass {
@@ -459,7 +460,7 @@ func (c *Checkup) checkPVCCreationAndBinding(ctx context.Context, errStr *string
 				UID:        types.UID(c.checkupConfig.PodUID),
 			}},
 			Annotations: map[string]string{
-				"cdi.kubevirt.io/storage.bind.immediate.requested": strTrue,
+				"cdi.kubevirt.io/storage.bind.immediate.requested": StrTrue,
 			},
 		},
 		Spec: cdiv1.DataVolumeSpec{
@@ -824,7 +825,7 @@ func (c *Checkup) Config() config.Config {
 func (c *Checkup) checkVMIBoot(ctx context.Context, errStr *string) error {
 	log.Print("checkVMIBoot")
 
-	if c.defaultStorageClass == "" {
+	if c.defaultStorageClass == "" && c.checkupConfig.StorageClass == "" {
 		log.Print(MessageSkipNoDefaultStorageClass)
 		c.results.VMBootFromGoldenImage = MessageSkipNoDefaultStorageClass
 		return nil
@@ -1029,7 +1030,7 @@ func (c *Checkup) checkConcurrentVMIBoot(ctx context.Context, errStr *string) er
 	numOfVMs := c.checkupConfig.NumOfVMs
 	log.Printf("checkConcurrentVMIBoot numOfVMs:%d", numOfVMs)
 
-	if c.defaultStorageClass == "" {
+	if c.defaultStorageClass == "" && c.checkupConfig.StorageClass == "" {
 		log.Print(MessageSkipNoDefaultStorageClass)
 		c.results.ConcurrentVMBoot = MessageSkipNoDefaultStorageClass
 		return nil

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -89,14 +89,24 @@ var tests = map[string]struct {
 	expectedErr     string
 }{
 	"noStorageClasses": {
-		clientConfig:    clientConfig{noStorageClasses: true},
-		expectedResults: map[string]string{reporter.DefaultStorageClassKey: checkup.ErrNoDefaultStorageClass},
-		expectedErr:     checkup.ErrNoDefaultStorageClass,
+		clientConfig: clientConfig{noStorageClasses: true, expectNoVMI: true},
+		expectedResults: map[string]string{
+			reporter.DefaultStorageClassKey:   checkup.ErrNoDefaultStorageClass,
+			reporter.PVCBoundKey:              checkup.MessageSkipNoDefaultStorageClass,
+			reporter.VMBootFromGoldenImageKey: checkup.MessageSkipNoDefaultStorageClass,
+			reporter.ConcurrentVMBootKey:      checkup.MessageSkipNoDefaultStorageClass,
+		},
+		expectedErr: checkup.ErrNoDefaultStorageClass,
 	},
 	"noDefaultStorageClass": {
-		clientConfig:    clientConfig{noDefaultStorageClass: true},
-		expectedResults: map[string]string{reporter.DefaultStorageClassKey: checkup.ErrNoDefaultStorageClass},
-		expectedErr:     checkup.ErrNoDefaultStorageClass,
+		clientConfig: clientConfig{noDefaultStorageClass: true, expectNoVMI: true},
+		expectedResults: map[string]string{
+			reporter.DefaultStorageClassKey:   checkup.ErrNoDefaultStorageClass,
+			reporter.PVCBoundKey:              checkup.MessageSkipNoDefaultStorageClass,
+			reporter.VMBootFromGoldenImageKey: checkup.MessageSkipNoDefaultStorageClass,
+			reporter.ConcurrentVMBootKey:      checkup.MessageSkipNoDefaultStorageClass,
+		},
+		expectedErr: checkup.ErrNoDefaultStorageClass,
 	},
 	"multipleDefaultStorageClasses": {
 		clientConfig:    clientConfig{multipleDefaultStorageClasses: true},
@@ -527,6 +537,10 @@ func (cs *clientStub) ListVolumeSnapshotClasses(ctx context.Context) (*snapshotv
 }
 
 func (cs *clientStub) ListDataImportCrons(ctx context.Context, namespace string) (*cdiv1.DataImportCronList, error) {
+	if namespace != testNamespace {
+		return &cdiv1.DataImportCronList{}, nil
+	}
+
 	dicList := &cdiv1.DataImportCronList{
 		Items: []cdiv1.DataImportCron{
 			{

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -606,6 +606,15 @@ func (cs *clientStub) ListVirtualMachinesInstances(ctx context.Context, namespac
 	return vmiList, nil
 }
 
+func (cs *clientStub) GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	return ns, nil
+}
+
 func (cs *clientStub) GetPersistentVolumeClaim(ctx context.Context, namespace, name string) (*corev1.PersistentVolumeClaim, error) {
 	blockMode := corev1.PersistentVolumeBlock
 	pvc := &corev1.PersistentVolumeClaim{

--- a/pkg/internal/client/client.go
+++ b/pkg/internal/client/client.go
@@ -132,6 +132,10 @@ func (c *Client) ListCDIs(ctx context.Context) (*cdiv1.CDIList, error) {
 	return c.CdiClient().CdiV1beta1().CDIs().List(ctx, metav1.ListOptions{})
 }
 
+func (c *Client) GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
+	return c.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+}
+
 func (c *Client) GetPersistentVolumeClaim(ctx context.Context, namespace, name string) (*corev1.PersistentVolumeClaim, error) {
 	return c.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
 }


### PR DESCRIPTION
- Skip checks when no default storage class - the PVC bound and VM checks cannot be executed without default storage class or default virt storage class, so skip them. Also added virt storage class support which was somehow missing.
- Prefer boot sources (official DataImportCrons and OS images) from the OpenShift Virtulization OS images namespace over other namespaces where users may have created test boot sources.
- Do not check PVC existence if VM DV source is snapshot.