### PR TITLE
Add VMSnapshot Test

### DIFF
--- a/manifests/storage_checkup.yaml
+++ b/manifests/storage_checkup.yaml
@@ -5,7 +5,10 @@ metadata:
   name: storage-checkup-config
   namespace: $CHECKUP_NAMESPACE
 data:
-  spec.timeout: 10m
+  # Overall job limit; 20m gives snapshot-clone + multi-check runs room on slow CI clusters (default 10m).
+  # Per-VM wait (boot, migration, hotplug); 10m avoids guest-agent timeout on first boot (default 3m).
+  spec.timeout: 20m
+  spec.param.vmiTimeout: 10m
 ---
 apiVersion: batch/v1
 kind: Job

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -36,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/kiagnose/kubevirt-storage-checkup/pkg/internal/config"
@@ -208,6 +209,10 @@ func (c *Checkup) Run(ctx context.Context) error {
 		return err
 	}
 	if err := c.checkVMIHotplugVolume(ctx, &errStr); err != nil {
+		return err
+	}
+
+	if err := c.checkVMSnapshot(ctx, &errStr); err != nil {
 		return err
 	}
 
@@ -833,6 +838,12 @@ func (c *Checkup) Teardown(ctx context.Context) error {
 		return fmt.Errorf("teardown: %v", err)
 	}
 
+	if c.snapshotName != "" {
+		if err := c.client.DeleteVirtualMachineSnapshot(ctx, c.namespace, c.snapshotName); ignoreNotFound(err) != nil {
+			return fmt.Errorf("teardown: %v", err)
+		}
+	}
+
 	return nil
 }
 
@@ -1154,6 +1165,107 @@ func (c *Checkup) waitForVMIStatus(ctx context.Context, vmName, checkMsg string,
 	return nil
 }
 
+// helper function to report VMSnapshot failure
+func (c *Checkup) reportVMSnapshotFailure(res string, errStr *string) {
+	log.Print(res)
+	appendSep(&c.results.VMSnapshot, res)
+	appendSep(errStr, res)
+}
+
+// helper function to wait for VMSnapshot to be ready
+func (c *Checkup) waitForVMSnapshotReady(ctx context.Context, snapshotName string, errStr *string) bool {
+	waitStart := time.Now()
+	log.Printf("Waiting for VMSnapshot %q ready (started at %s)", snapshotName, waitStart.Format(time.RFC3339))
+	err := wait.PollImmediateWithContext(ctx, pollInterval, c.checkupConfig.VMITimeout, func(ctx context.Context) (bool, error) {
+		snapshot, err := c.client.GetVirtualMachineSnapshot(ctx, c.namespace, snapshotName)
+		if err != nil {
+			return false, ignoreNotFound(err)
+		}
+		if snapshot.Status != nil && snapshot.Status.ReadyToUse != nil && *snapshot.Status.ReadyToUse {
+			return true, nil
+		}
+		if snapshot.Status != nil && snapshot.Status.Phase == snapshotv1alpha1.Failed {
+			return false, errors.New("snapshot failed")
+		}
+		return false, nil
+	})
+	elapsed := time.Since(waitStart).Round(time.Millisecond)
+	if err != nil {
+		c.reportVMSnapshotFailure(
+			fmt.Sprintf("failed waiting for VMSnapshot %q after %s: %v", snapshotName, elapsed, err),
+			errStr,
+		)
+		return true
+	}
+	log.Printf("VMSnapshot %q ReadyToUse after %s", snapshotName, elapsed)
+	return false
+}
+
+// validateVMSnapshot checks phase, indications, and volumes.
+// Returns true if validation failed (already reported).
+func (c *Checkup) validateVMSnapshot(snapshot *snapshotv1alpha1.VirtualMachineSnapshot, snapshotName string, errStr *string) bool {
+	if snapshot.Status == nil || snapshot.Status.Phase != snapshotv1alpha1.Succeeded {
+		phase := "has no status"
+		if snapshot.Status != nil {
+			phase = string(snapshot.Status.Phase)
+		}
+		c.reportVMSnapshotFailure(fmt.Sprintf("VMSnapshot %q phase is %s, expected Succeeded", snapshotName, phase), errStr)
+		return true
+	}
+
+	expected := sets.New(
+		snapshotv1alpha1.VMSnapshotOnlineSnapshotIndication,
+		snapshotv1alpha1.VMSnapshotGuestAgentIndication,
+	)
+	actual := sets.New[snapshotv1alpha1.Indication](snapshot.Status.Indications...)
+	if unexpected := actual.Difference(expected); unexpected.Len() > 0 {
+		c.reportVMSnapshotFailure(
+			fmt.Sprintf("VMSnapshot %q has unexpected indication(s): %v", snapshotName, sets.List(unexpected)),
+			errStr,
+		)
+		return true
+	}
+	if missing := expected.Difference(actual); missing.Len() > 0 {
+		c.reportVMSnapshotFailure(
+			fmt.Sprintf("VMSnapshot %q missing expected indication(s): %v", snapshotName, sets.List(missing)),
+			errStr,
+		)
+		return true
+	}
+
+	if snapshot.Status.SnapshotVolumes == nil {
+		c.reportVMSnapshotFailure(fmt.Sprintf("VMSnapshot %q has no SnapshotVolumes", snapshotName), errStr)
+		return true
+	}
+
+	// Require every volume from the VM template to be included. Extra included
+	// volumes (e.g. persistent TPM state) are OK and common on real clusters.
+	expectedVolumes := sets.New[string]()
+	for _, vol := range c.vmUnderTest.Spec.Template.Spec.Volumes {
+		expectedVolumes.Insert(vol.Name)
+	}
+	includedVolumes := sets.New(snapshot.Status.SnapshotVolumes.IncludedVolumes...)
+	excludedVolumes := sets.New(snapshot.Status.SnapshotVolumes.ExcludedVolumes...)
+
+	if missing := expectedVolumes.Difference(includedVolumes); missing.Len() > 0 {
+		c.reportVMSnapshotFailure(
+			fmt.Sprintf("VMSnapshot %q missing expected volume(s): %v (included: %v)",
+				snapshotName, sets.List(missing), sets.List(includedVolumes)),
+			errStr,
+		)
+		return true
+	}
+	if excluded := expectedVolumes.Intersection(excludedVolumes); excluded.Len() > 0 {
+		c.reportVMSnapshotFailure(
+			fmt.Sprintf("VMSnapshot %q excluded expected volume(s): %v", snapshotName, sets.List(excluded)),
+			errStr,
+		)
+		return true
+	}
+
+	return false
+}
+
 func (c *Checkup) checkVMSnapshot(ctx context.Context, errStr *string) error {
 	log.Print("checkVMSnapshot")
 	apiGroup := "kubevirt.io"
@@ -1179,27 +1291,15 @@ func (c *Checkup) checkVMSnapshot(ctx context.Context, errStr *string) error {
 	}
 
 	// create snapshot, if failed: return error
+	createStart := time.Now()
+	log.Printf("Creating VMSnapshot %q at %s", snapshotName, createStart.Format(time.RFC3339))
 	if _, err := c.client.CreateVirtualMachineSnapshot(ctx, c.namespace, vmSnapshot); err != nil {
 		return fmt.Errorf("failed to create VMSnapshot: %w", err)
 	}
-	log.Printf("Waiting for VMSnapshot %q ready", snapshotName)
-	if err := wait.PollImmediateWithContext(ctx, pollInterval, c.checkupConfig.VMITimeout, func(ctx context.Context) (bool, error) {
-		snapshot, err := c.client.GetVirtualMachineSnapshot(ctx, c.namespace, snapshotName)
-		if err != nil {
-			return false, ignoreNotFound(err)
-		}
-		if snapshot.Status != nil && snapshot.Status.ReadyToUse != nil && *snapshot.Status.ReadyToUse {
-			return true, nil
-		}
-		if snapshot.Status != nil && snapshot.Status.Phase == snapshotv1alpha1.Failed {
-			return false, errors.New("snapshot failed")
-		}
-		return false, nil
-	}); err != nil {
-		res := fmt.Sprintf("failed waiting for VMSnapshot %q: %v", snapshotName, err)
-		log.Print(res)
-		c.results.VMSnapshot = res
-		appendSep(errStr, res)
+	log.Printf("VMSnapshot %q created in %s", snapshotName, time.Since(createStart).Round(time.Millisecond))
+
+	// wait for snapshot to be ready, if failed: return error
+	if c.waitForVMSnapshotReady(ctx, snapshotName, errStr) {
 		return nil
 	}
 
@@ -1208,63 +1308,7 @@ func (c *Checkup) checkVMSnapshot(ctx context.Context, errStr *string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get VMSnapshot %q: %w", snapshotName, err)
 	}
-	if snapshot.Status.Phase != snapshotv1alpha1.Succeeded {
-		res := fmt.Sprintf("VMSnapshot %q phase is %s, expected Succeeded", snapshotName, snapshot.Status.Phase)
-		log.Print(res)
-		appendSep(&c.results.VMSnapshot, res)
-		appendSep(errStr, res)
-		return nil
-	}
-
-	// validate the indications
-	expectedIndications := map[snapshotv1alpha1.Indication]bool{
-		snapshotv1alpha1.VMSnapshotOnlineSnapshotIndication: false,
-		snapshotv1alpha1.VMSnapshotGuestAgentIndication:     false,
-	}
-	for _, ind := range snapshot.Status.Indications {
-		if _, expected := expectedIndications[ind]; !expected {
-			res := fmt.Sprintf("VMSnapshot %q has unexpected indication: %s", snapshotName, ind)
-			log.Print(res)
-			appendSep(&c.results.VMSnapshot, res)
-			appendSep(errStr, res)
-			return nil
-		}
-		expectedIndications[ind] = true
-	}
-	for ind, found := range expectedIndications {
-		if !found {
-			res := fmt.Sprintf("VMSnapshot %q missing expected indication: %s", snapshotName, ind)
-			log.Print(res)
-			appendSep(&c.results.VMSnapshot, res)
-			appendSep(errStr, res)
-			return nil
-		}
-	}
-
-	// validate the snapshot volumes
-	if snapshot.Status.SnapshotVolumes == nil {
-		res := fmt.Sprintf("VMSnapshot %q has no SnapshotVolumes", snapshotName)
-		log.Print(res)
-		appendSep(&c.results.VMSnapshot, res)
-		appendSep(errStr, res)
-		return nil
-	}
-
-	expectedVolumeCount := len(c.vmUnderTest.Spec.Template.Spec.Volumes)
-	actualVolumeCount := len(snapshot.Status.SnapshotVolumes.IncludedVolumes)
-	if actualVolumeCount != expectedVolumeCount {
-		res := fmt.Sprintf("VMSnapshot %q included %d volumes, expected %d", snapshotName, actualVolumeCount, expectedVolumeCount)
-		log.Print(res)
-		appendSep(&c.results.VMSnapshot, res)
-		appendSep(errStr, res)
-		return nil
-	}
-
-	if len(snapshot.Status.SnapshotVolumes.ExcludedVolumes) > 0 {
-		res := fmt.Sprintf("VMSnapshot %q has excluded volumes: %v", snapshotName, snapshot.Status.SnapshotVolumes.ExcludedVolumes)
-		log.Print(res)
-		appendSep(&c.results.VMSnapshot, res)
-		appendSep(errStr, res)
+	if c.validateVMSnapshot(snapshot, snapshotName, errStr) {
 		return nil
 	}
 	c.snapshotName = snapshotName

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -46,6 +46,8 @@ import (
 
 	kvcorev1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	snapshotv1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 )
 
 type kubeVirtStorageClient interface {
@@ -75,6 +77,14 @@ type kubeVirtStorageClient interface {
 	GetCSIDriver(ctx context.Context, name string) (*storagev1.CSIDriver, error)
 	GetDataSource(ctx context.Context, namespace, name string) (*cdiv1.DataSource, error)
 	GetClusterVersion(ctx context.Context, name string) (*configv1.ClusterVersion, error)
+	CreateVirtualMachineSnapshot(ctx context.Context, namespace string,
+		snapshot *snapshotv1alpha1.VirtualMachineSnapshot) (*snapshotv1alpha1.VirtualMachineSnapshot, error)
+	GetVirtualMachineSnapshot(ctx context.Context, namespace, name string) (*snapshotv1alpha1.VirtualMachineSnapshot, error)
+	DeleteVirtualMachineSnapshot(ctx context.Context, namespace, name string) error
+	GetVirtualMachineSnapshotContent(ctx context.Context, namespace, name string) (*snapshotv1alpha1.VirtualMachineSnapshotContent, error)
+	CreateVirtualMachineRestore(ctx context.Context, namespace string, restore *snapshotv1alpha1.VirtualMachineRestore) (*snapshotv1alpha1.VirtualMachineRestore, error)
+	GetVirtualMachineRestore(ctx context.Context, namespace, name string) (*snapshotv1alpha1.VirtualMachineRestore, error)
+	DeleteVirtualMachineRestore(ctx context.Context, namespace, name string) error
 }
 
 const (
@@ -126,6 +136,7 @@ type Checkup struct {
 	goldenImageSnap     *snapshotv1.VolumeSnapshot
 	vmUnderTest         *kvcorev1.VirtualMachine
 	results             status.Results
+	snapshotName        string
 }
 
 type goldenImagesCheckState struct {
@@ -1140,6 +1151,127 @@ func (c *Checkup) waitForVMIStatus(ctx context.Context, vmName, checkMsg string,
 	log.Print(res)
 	appendSep(result, res)
 
+	return nil
+}
+
+func (c *Checkup) checkVMSnapshot(ctx context.Context, errStr *string) error {
+	log.Print("checkVMSnapshot")
+	apiGroup := "kubevirt.io"
+	// if no VM created: skip that test
+	if c.vmUnderTest == nil {
+		log.Print(MessageSkipNoVMI)
+		c.results.VMSnapshot = MessageSkipNoVMI
+		return nil
+	}
+	vmName := c.vmUnderTest.Name
+	snapshotName := fmt.Sprintf("snapshot-%s", vmName)
+	vmSnapshot := &snapshotv1alpha1.VirtualMachineSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: snapshotName,
+		},
+		Spec: snapshotv1alpha1.VirtualMachineSnapshotSpec{
+			Source: corev1.TypedLocalObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     "VirtualMachine",
+				Name:     vmName,
+			},
+		},
+	}
+
+	// create snapshot, if failed: return error
+	if _, err := c.client.CreateVirtualMachineSnapshot(ctx, c.namespace, vmSnapshot); err != nil {
+		return fmt.Errorf("failed to create VMSnapshot: %w", err)
+	}
+	log.Printf("Waiting for VMSnapshot %q ready", snapshotName)
+	if err := wait.PollImmediateWithContext(ctx, pollInterval, c.checkupConfig.VMITimeout, func(ctx context.Context) (bool, error) {
+		snapshot, err := c.client.GetVirtualMachineSnapshot(ctx, c.namespace, snapshotName)
+		if err != nil {
+			return false, ignoreNotFound(err)
+		}
+		if snapshot.Status != nil && snapshot.Status.ReadyToUse != nil && *snapshot.Status.ReadyToUse {
+			return true, nil
+		}
+		if snapshot.Status != nil && snapshot.Status.Phase == snapshotv1alpha1.Failed {
+			return false, errors.New("snapshot failed")
+		}
+		return false, nil
+	}); err != nil {
+		res := fmt.Sprintf("failed waiting for VMSnapshot %q: %v", snapshotName, err)
+		log.Print(res)
+		c.results.VMSnapshot = res
+		appendSep(errStr, res)
+		return nil
+	}
+
+	// validate the snapshot
+	snapshot, err := c.client.GetVirtualMachineSnapshot(ctx, c.namespace, snapshotName)
+	if err != nil {
+		return fmt.Errorf("failed to get VMSnapshot %q: %w", snapshotName, err)
+	}
+	if snapshot.Status.Phase != snapshotv1alpha1.Succeeded {
+		res := fmt.Sprintf("VMSnapshot %q phase is %s, expected Succeeded", snapshotName, snapshot.Status.Phase)
+		log.Print(res)
+		appendSep(&c.results.VMSnapshot, res)
+		appendSep(errStr, res)
+		return nil
+	}
+
+	// validate the indications
+	expectedIndications := map[snapshotv1alpha1.Indication]bool{
+		snapshotv1alpha1.VMSnapshotOnlineSnapshotIndication: false,
+		snapshotv1alpha1.VMSnapshotGuestAgentIndication:     false,
+	}
+	for _, ind := range snapshot.Status.Indications {
+		if _, expected := expectedIndications[ind]; !expected {
+			res := fmt.Sprintf("VMSnapshot %q has unexpected indication: %s", snapshotName, ind)
+			log.Print(res)
+			appendSep(&c.results.VMSnapshot, res)
+			appendSep(errStr, res)
+			return nil
+		}
+		expectedIndications[ind] = true
+	}
+	for ind, found := range expectedIndications {
+		if !found {
+			res := fmt.Sprintf("VMSnapshot %q missing expected indication: %s", snapshotName, ind)
+			log.Print(res)
+			appendSep(&c.results.VMSnapshot, res)
+			appendSep(errStr, res)
+			return nil
+		}
+	}
+
+	// validate the snapshot volumes
+	if snapshot.Status.SnapshotVolumes == nil {
+		res := fmt.Sprintf("VMSnapshot %q has no SnapshotVolumes", snapshotName)
+		log.Print(res)
+		appendSep(&c.results.VMSnapshot, res)
+		appendSep(errStr, res)
+		return nil
+	}
+
+	expectedVolumeCount := len(c.vmUnderTest.Spec.Template.Spec.Volumes)
+	actualVolumeCount := len(snapshot.Status.SnapshotVolumes.IncludedVolumes)
+	if actualVolumeCount != expectedVolumeCount {
+		res := fmt.Sprintf("VMSnapshot %q included %d volumes, expected %d", snapshotName, actualVolumeCount, expectedVolumeCount)
+		log.Print(res)
+		appendSep(&c.results.VMSnapshot, res)
+		appendSep(errStr, res)
+		return nil
+	}
+
+	if len(snapshot.Status.SnapshotVolumes.ExcludedVolumes) > 0 {
+		res := fmt.Sprintf("VMSnapshot %q has excluded volumes: %v", snapshotName, snapshot.Status.SnapshotVolumes.ExcludedVolumes)
+		log.Print(res)
+		appendSep(&c.results.VMSnapshot, res)
+		appendSep(errStr, res)
+		return nil
+	}
+	c.snapshotName = snapshotName
+
+	res := fmt.Sprintf("VMSnapshot for VM %q succeeded", vmName)
+	log.Print(res)
+	c.results.VMSnapshot = res
 	return nil
 }
 

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -792,8 +792,10 @@ func (cs *clientStub) CreateVirtualMachineSnapshot(ctx context.Context, namespac
 		includedVolumes = append(includedVolumes, volume.Name)
 	}
 
+	contentName := fmt.Sprintf("%s-content", snapshot.Name)
 	readyToUse := true
 	snapshot.Status = &snapshotv1alpha1.VirtualMachineSnapshotStatus{
+		VirtualMachineSnapshotContentName: &contentName,
 		Phase:      snapshotv1alpha1.Succeeded,
 		ReadyToUse: &readyToUse,
 		Indications: []snapshotv1alpha1.Indication{
@@ -822,6 +824,112 @@ func (cs *clientStub) DeleteVirtualMachineSnapshot(ctx context.Context, namespac
 	delete(cs.createdSnapshots, snapshotFullName)
 	return nil
 }
+
+func (cs *clientStub) GetVirtualMachineSnapshotContent(ctx context.Context, namespace, name string) (*snapshotv1alpha1.VirtualMachineSnapshotContent, error) {
+	var snapshot *snapshotv1alpha1.VirtualMachineSnapshot
+	for _, s := range cs.createdSnapshots {
+		if s.Status.VirtualMachineSnapshotContentName != nil && *s.Status.VirtualMachineSnapshotContentName == name{
+			snapshot = s
+			break
+		}
+	}
+	if snapshot == nil {
+		return nil, errors.NewNotFound(schema.GroupResource{Group: "snapshot.kubevirt.io", Resource: "virtualmachinesnapshotcontents"}, name)
+	}
+	vmFullName := objectFullName(namespace, snapshot.Spec.Source.Name)
+	vm, exists := cs.createdVMs[vmFullName]
+	if !exists {
+		return nil, errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachines"}, vmFullName)
+	}
+
+	readyToUse := true
+	var volumeBackups []snapshotv1alpha1.VolumeBackup                                                                                        
+	var volumeSnapshotStatuses []snapshotv1alpha1.VolumeSnapshotStatus
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		vsName := fmt.Sprintf("vs-%s", volume.Name)                                                                                             
+		volumeBackups = append(volumeBackups, snapshotv1alpha1.VolumeBackup{
+			VolumeName: volume.Name,
+			PersistentVolumeClaim: snapshotv1alpha1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: volume.Name,
+				},
+			},
+			VolumeSnapshotName: &vsName,
+		})
+		volumeSnapshotStatuses = append(volumeSnapshotStatuses, snapshotv1alpha1.VolumeSnapshotStatus{
+			VolumeSnapshotName: vsName,
+			ReadyToUse: &readyToUse,
+		})
+	}
+
+	return &snapshotv1alpha1.VirtualMachineSnapshotContent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: snapshotv1alpha1.VirtualMachineSnapshotContentSpec{
+			VolumeBackups: volumeBackups,
+		},
+		Status: &snapshotv1alpha1.VirtualMachineSnapshotContentStatus{
+			ReadyToUse:           &readyToUse,
+			VolumeSnapshotStatus: volumeSnapshotStatuses,
+		},
+	}, nil		  
+}
+
+func (cs *clientStub) CreateVirtualMachineRestore(ctx context.Context, namespace string,
+    restore *snapshotv1alpha1.VirtualMachineRestore) (*snapshotv1alpha1.VirtualMachineRestore, error) {
+    restore.Namespace = namespace
+    // 1. snapshot
+    snapshotFullName := objectFullName(namespace, restore.Spec.VirtualMachineSnapshotName)
+    snapshot, exists := cs.createdSnapshots[snapshotFullName]
+    if !exists {
+		return nil, errors.NewNotFound(schema.GroupResource{Group: "snapshot.kubevirt.io", Resource: "virtualmachinesnapshots"},   
+		restore.Spec.VirtualMachineSnapshotName)
+	}
+    // 2. VM from snapshot source
+    vmFullName := objectFullName(namespace, snapshot.Spec.Source.Name)
+    vm, exists := cs.createdVMs[vmFullName]
+    if !exists {
+        return nil, fmt.Errorf("virtual machine %s not found", vmFullName)
+    }
+    // 3. build status from VM disks
+    var restores []snapshotv1alpha1.VolumeRestore
+    for _, vol := range vm.Spec.Template.Spec.Volumes {
+		vsName := fmt.Sprintf("vs-%s", vol.Name)                                                                                   
+		restores = append(restores, snapshotv1alpha1.VolumeRestore{                                                                
+				VolumeName:            vol.Name,                                                                                   
+				PersistentVolumeClaimName: vol.Name,                                                                               
+				VolumeSnapshotName:    vsName,                                                                 
+		}) 
+	}
+	var deletedDVs []string
+	for _, dvt := range vm.Spec.DataVolumeTemplates {
+		deletedDVs = append(deletedDVs, dvt.Name)
+	}
+	
+	complete := true
+	restore.Status = &snapshotv1alpha1.VirtualMachineRestoreStatus{
+		Complete: &complete,
+		RestoreTime: &metav1.Time{Time: time.Now()},
+		Restores: restores,
+		DeletedDataVolumes: deletedDVs,
+		Conditions: []snapshotv1alpha1.Condition{
+			{
+				Type: snapshotv1alpha1.ConditionReady,
+				Status: corev1.ConditionTrue,
+			},
+			{
+				Type: snapshotv1alpha1.ConditionProgressing,
+				Status: corev1.ConditionFalse,
+			},
+		},
+	}
+	cs.createdRestores[objectFullName(namespace, restore.Name)] = restore
+	return restore, nil
+}
+
+func (cs *clientStub) GetVirtualMachineRestore(ctx context.Context, namespace, name string) (*snapshotv1alpha1.VirtualMachineRestore, error) {
 
 func (cs *clientStub) ListCDIs(ctx context.Context) (*cdiv1.CDIList, error) {
 	cdis := &cdiv1.CDIList{

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -42,6 +42,8 @@ import (
 	"github.com/kiagnose/kubevirt-storage-checkup/pkg/internal/checkup"
 	"github.com/kiagnose/kubevirt-storage-checkup/pkg/internal/config"
 	"github.com/kiagnose/kubevirt-storage-checkup/pkg/internal/reporter"
+
+	snapshotv1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 )
 
 const (
@@ -300,6 +302,8 @@ type clientConfig struct {
 type clientStub struct {
 	createdVMs        map[string]*kvcorev1.VirtualMachine
 	createdVMIs       map[string]*kvcorev1.VirtualMachineInstance
+	createdSnapshots  map[string]*snapshotv1alpha1.VirtualMachineSnapshot
+	createdRestores   map[string]*snapshotv1alpha1.VirtualMachineRestore
 	vmCreationFailure error
 	vmDeletionFailure error
 	vmiGetFailure     error
@@ -308,9 +312,11 @@ type clientStub struct {
 
 func newClientStub(clientConfig clientConfig) *clientStub {
 	return &clientStub{
-		createdVMs:   map[string]*kvcorev1.VirtualMachine{},
-		createdVMIs:  map[string]*kvcorev1.VirtualMachineInstance{},
-		clientConfig: clientConfig,
+		createdVMs:       map[string]*kvcorev1.VirtualMachine{},
+		createdVMIs:      map[string]*kvcorev1.VirtualMachineInstance{},
+		createdSnapshots: map[string]*snapshotv1alpha1.VirtualMachineSnapshot{},
+		createdRestores:  map[string]*snapshotv1alpha1.VirtualMachineRestore{},
+		clientConfig:     clientConfig,
 	}
 }
 
@@ -770,6 +776,51 @@ func (cs *clientStub) GetClusterVersion(ctx context.Context, name string) (*conf
 	}
 
 	return ver, nil
+}
+
+func (cs *clientStub) CreateVirtualMachineSnapshot(ctx context.Context, namespace string, snapshot *snapshotv1alpha1.VirtualMachineSnapshot) (*snapshotv1alpha1.VirtualMachineSnapshot, error) {
+	snapshot.Namespace = namespace
+	snapshotFullName := objectFullName(snapshot.Namespace, snapshot.Name)
+	cs.createdSnapshots[snapshotFullName] = snapshot
+	vmFullName := objectFullName(namespace, snapshot.Spec.Source.Name)
+	vm, exists := cs.createdVMs[vmFullName]
+	if !exists {
+		return nil, fmt.Errorf("virtual machine %s not found", vmFullName)
+	}
+	var includedVolumes []string
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		includedVolumes = append(includedVolumes, volume.Name)
+	}
+
+	readyToUse := true
+	snapshot.Status = &snapshotv1alpha1.VirtualMachineSnapshotStatus{
+		Phase:      snapshotv1alpha1.Succeeded,
+		ReadyToUse: &readyToUse,
+		Indications: []snapshotv1alpha1.Indication{
+			snapshotv1alpha1.VMSnapshotOnlineSnapshotIndication,
+			snapshotv1alpha1.VMSnapshotGuestAgentIndication,
+		},
+		SnapshotVolumes: &snapshotv1alpha1.SnapshotVolumesLists{
+			IncludedVolumes: includedVolumes,
+			ExcludedVolumes: []string{},
+		},
+	}
+	return snapshot, nil
+}
+
+func (cs *clientStub) GetVirtualMachineSnapshot(ctx context.Context, namespace, name string) (*snapshotv1alpha1.VirtualMachineSnapshot, error) {
+	snapshotFullName := objectFullName(namespace, name)
+	snapshot, exists := cs.createdSnapshots[snapshotFullName]
+	if !exists {
+		return nil, errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachinesnapshots"}, name)
+	}
+	return snapshot, nil
+}
+
+func (cs *clientStub) DeleteVirtualMachineSnapshot(ctx context.Context, namespace, name string) error {
+	snapshotFullName := objectFullName(namespace, name)
+	delete(cs.createdSnapshots, snapshotFullName)
+	return nil
 }
 
 func (cs *clientStub) ListCDIs(ctx context.Context) (*cdiv1.CDIList, error) {

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -251,6 +251,7 @@ func fullExpectedResults(vmiUnderTestName string, expectedResults map[string]str
 func expectedResultsNoVMI(expectedResults map[string]string) {
 	expectedResults[reporter.VMHotplugVolumeKey] = checkup.MessageSkipNoVMI
 	expectedResults[reporter.VMLiveMigrationKey] = checkup.MessageSkipNoVMI
+	expectedResults[reporter.VMSnapshotKey] = checkup.MessageSkipNoVMI
 	expectedResults[reporter.VMVolumeCloneKey] = ""
 }
 
@@ -276,6 +277,8 @@ func successfulRunResults(vmiUnderTestName string) map[string]string {
 		reporter.VMHotplugVolumeKey: fmt.Sprintf("VMI %q hotplug volume ready\nVMI %q hotplug volume removed",
 			vmiUnderTestName, vmiUnderTestName),
 		reporter.ConcurrentVMBootKey: "Boot completed on all VMs on time",
+		reporter.VMSnapshotKey:       fmt.Sprintf("VMSnapshot for VM %q succeeded", vmiUnderTestName),
+		reporter.VMRestoreKey:        "",
 	}
 }
 

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	configv1 "github.com/openshift/api/config/v1"
@@ -796,8 +797,8 @@ func (cs *clientStub) CreateVirtualMachineSnapshot(ctx context.Context, namespac
 	readyToUse := true
 	snapshot.Status = &snapshotv1alpha1.VirtualMachineSnapshotStatus{
 		VirtualMachineSnapshotContentName: &contentName,
-		Phase:      snapshotv1alpha1.Succeeded,
-		ReadyToUse: &readyToUse,
+		Phase:                             snapshotv1alpha1.Succeeded,
+		ReadyToUse:                        &readyToUse,
 		Indications: []snapshotv1alpha1.Indication{
 			snapshotv1alpha1.VMSnapshotOnlineSnapshotIndication,
 			snapshotv1alpha1.VMSnapshotGuestAgentIndication,
@@ -828,7 +829,7 @@ func (cs *clientStub) DeleteVirtualMachineSnapshot(ctx context.Context, namespac
 func (cs *clientStub) GetVirtualMachineSnapshotContent(ctx context.Context, namespace, name string) (*snapshotv1alpha1.VirtualMachineSnapshotContent, error) {
 	var snapshot *snapshotv1alpha1.VirtualMachineSnapshot
 	for _, s := range cs.createdSnapshots {
-		if s.Status.VirtualMachineSnapshotContentName != nil && *s.Status.VirtualMachineSnapshotContentName == name{
+		if s.Status.VirtualMachineSnapshotContentName != nil && *s.Status.VirtualMachineSnapshotContentName == name {
 			snapshot = s
 			break
 		}
@@ -843,10 +844,10 @@ func (cs *clientStub) GetVirtualMachineSnapshotContent(ctx context.Context, name
 	}
 
 	readyToUse := true
-	var volumeBackups []snapshotv1alpha1.VolumeBackup                                                                                        
+	var volumeBackups []snapshotv1alpha1.VolumeBackup
 	var volumeSnapshotStatuses []snapshotv1alpha1.VolumeSnapshotStatus
 	for _, volume := range vm.Spec.Template.Spec.Volumes {
-		vsName := fmt.Sprintf("vs-%s", volume.Name)                                                                                             
+		vsName := fmt.Sprintf("vs-%s", volume.Name)
 		volumeBackups = append(volumeBackups, snapshotv1alpha1.VolumeBackup{
 			VolumeName: volume.Name,
 			PersistentVolumeClaim: snapshotv1alpha1.PersistentVolumeClaim{
@@ -858,7 +859,7 @@ func (cs *clientStub) GetVirtualMachineSnapshotContent(ctx context.Context, name
 		})
 		volumeSnapshotStatuses = append(volumeSnapshotStatuses, snapshotv1alpha1.VolumeSnapshotStatus{
 			VolumeSnapshotName: vsName,
-			ReadyToUse: &readyToUse,
+			ReadyToUse:         &readyToUse,
 		})
 	}
 
@@ -874,53 +875,53 @@ func (cs *clientStub) GetVirtualMachineSnapshotContent(ctx context.Context, name
 			ReadyToUse:           &readyToUse,
 			VolumeSnapshotStatus: volumeSnapshotStatuses,
 		},
-	}, nil		  
+	}, nil
 }
 
 func (cs *clientStub) CreateVirtualMachineRestore(ctx context.Context, namespace string,
-    restore *snapshotv1alpha1.VirtualMachineRestore) (*snapshotv1alpha1.VirtualMachineRestore, error) {
-    restore.Namespace = namespace
-    // 1. snapshot
-    snapshotFullName := objectFullName(namespace, restore.Spec.VirtualMachineSnapshotName)
-    snapshot, exists := cs.createdSnapshots[snapshotFullName]
-    if !exists {
-		return nil, errors.NewNotFound(schema.GroupResource{Group: "snapshot.kubevirt.io", Resource: "virtualmachinesnapshots"},   
-		restore.Spec.VirtualMachineSnapshotName)
+	restore *snapshotv1alpha1.VirtualMachineRestore) (*snapshotv1alpha1.VirtualMachineRestore, error) {
+	restore.Namespace = namespace
+	// 1. snapshot
+	snapshotFullName := objectFullName(namespace, restore.Spec.VirtualMachineSnapshotName)
+	snapshot, exists := cs.createdSnapshots[snapshotFullName]
+	if !exists {
+		return nil, errors.NewNotFound(schema.GroupResource{Group: "snapshot.kubevirt.io", Resource: "virtualmachinesnapshots"},
+			restore.Spec.VirtualMachineSnapshotName)
 	}
-    // 2. VM from snapshot source
-    vmFullName := objectFullName(namespace, snapshot.Spec.Source.Name)
-    vm, exists := cs.createdVMs[vmFullName]
-    if !exists {
-        return nil, fmt.Errorf("virtual machine %s not found", vmFullName)
-    }
-    // 3. build status from VM disks
-    var restores []snapshotv1alpha1.VolumeRestore
-    for _, vol := range vm.Spec.Template.Spec.Volumes {
-		vsName := fmt.Sprintf("vs-%s", vol.Name)                                                                                   
-		restores = append(restores, snapshotv1alpha1.VolumeRestore{                                                                
-				VolumeName:            vol.Name,                                                                                   
-				PersistentVolumeClaimName: vol.Name,                                                                               
-				VolumeSnapshotName:    vsName,                                                                 
-		}) 
+	// 2. VM from snapshot source
+	vmFullName := objectFullName(namespace, snapshot.Spec.Source.Name)
+	vm, exists := cs.createdVMs[vmFullName]
+	if !exists {
+		return nil, fmt.Errorf("virtual machine %s not found", vmFullName)
+	}
+	// 3. build status from VM disks
+	var restores []snapshotv1alpha1.VolumeRestore
+	for _, vol := range vm.Spec.Template.Spec.Volumes {
+		vsName := fmt.Sprintf("vs-%s", vol.Name)
+		restores = append(restores, snapshotv1alpha1.VolumeRestore{
+			VolumeName:                vol.Name,
+			PersistentVolumeClaimName: vol.Name,
+			VolumeSnapshotName:        vsName,
+		})
 	}
 	var deletedDVs []string
 	for _, dvt := range vm.Spec.DataVolumeTemplates {
 		deletedDVs = append(deletedDVs, dvt.Name)
 	}
-	
+
 	complete := true
 	restore.Status = &snapshotv1alpha1.VirtualMachineRestoreStatus{
-		Complete: &complete,
-		RestoreTime: &metav1.Time{Time: time.Now()},
-		Restores: restores,
+		Complete:           &complete,
+		RestoreTime:        &metav1.Time{Time: time.Now()},
+		Restores:           restores,
 		DeletedDataVolumes: deletedDVs,
 		Conditions: []snapshotv1alpha1.Condition{
 			{
-				Type: snapshotv1alpha1.ConditionReady,
+				Type:   snapshotv1alpha1.ConditionReady,
 				Status: corev1.ConditionTrue,
 			},
 			{
-				Type: snapshotv1alpha1.ConditionProgressing,
+				Type:   snapshotv1alpha1.ConditionProgressing,
 				Status: corev1.ConditionFalse,
 			},
 		},
@@ -930,6 +931,19 @@ func (cs *clientStub) CreateVirtualMachineRestore(ctx context.Context, namespace
 }
 
 func (cs *clientStub) GetVirtualMachineRestore(ctx context.Context, namespace, name string) (*snapshotv1alpha1.VirtualMachineRestore, error) {
+	restoreFullName := objectFullName(namespace, name)
+	restore, exists := cs.createdRestores[restoreFullName]
+	if !exists {
+		return nil, errors.NewNotFound(schema.GroupResource{Group: "snapshot.kubevirt.io", Resource: "virtualmachinerestores"}, name)
+	}
+	return restore, nil
+}
+
+func (cs *clientStub) DeleteVirtualMachineRestore(ctx context.Context, namespace, name string) error {
+	restoreFullName := objectFullName(namespace, name)
+	delete(cs.createdRestores, restoreFullName)
+	return nil
+}
 
 func (cs *clientStub) ListCDIs(ctx context.Context) (*cdiv1.CDIList, error) {
 	cdis := &cdiv1.CDIList{

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -69,6 +69,15 @@ func newVMUnderTest(name string, pvc *corev1.PersistentVolumeClaim, snap *snapsh
 		optionsToApply = append(optionsToApply, vmi.WithDataVolume(blankDvName, dvOpts...))
 	}
 
+	for i := 1; i <= checkupConfig.NumOfDataVolumes; i++ {
+		dataDvName := fmt.Sprintf("%s-data-%d", dvName, i)
+		dvOpts := []vmi.DataVolumeOption{vmi.WithDataVolumeBlankSource()}
+		if checkupConfig.StorageClass != "" {
+			dvOpts = append(dvOpts, vmi.WithDataVolumeStorageClass(checkupConfig.StorageClass))
+		}
+		optionsToApply = append(optionsToApply, vmi.WithDataVolume(dataDvName, dvOpts...))
+	}
+
 	return vmi.NewVM(name, optionsToApply...)
 }
 

--- a/pkg/internal/client/client.go
+++ b/pkg/internal/client/client.go
@@ -34,6 +34,8 @@ import (
 	kvcorev1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	snapshotv1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 )
 
 type Client struct {
@@ -158,4 +160,37 @@ func (c *Client) GetDataSource(ctx context.Context, namespace, name string) (*cd
 
 func (c *Client) GetClusterVersion(ctx context.Context, name string) (*configv1.ClusterVersion, error) {
 	return c.ClusterVersions().Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c *Client) CreateVirtualMachineSnapshot(ctx context.Context, namespace string,
+	snapshot *snapshotv1alpha1.VirtualMachineSnapshot) (*snapshotv1alpha1.VirtualMachineSnapshot, error) {
+	return c.VirtualMachineSnapshot(namespace).Create(ctx, snapshot, metav1.CreateOptions{})
+}
+
+func (c *Client) GetVirtualMachineSnapshot(ctx context.Context, namespace, name string) (
+	*snapshotv1alpha1.VirtualMachineSnapshot, error) {
+	return c.VirtualMachineSnapshot(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c *Client) DeleteVirtualMachineSnapshot(ctx context.Context, namespace, name string) error {
+	return c.VirtualMachineSnapshot(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+}
+
+func (c *Client) GetVirtualMachineSnapshotContent(ctx context.Context, namespace, name string) (
+	*snapshotv1alpha1.VirtualMachineSnapshotContent, error) {
+	return c.VirtualMachineSnapshotContent(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c *Client) CreateVirtualMachineRestore(ctx context.Context, namespace string,
+	restore *snapshotv1alpha1.VirtualMachineRestore) (*snapshotv1alpha1.VirtualMachineRestore, error) {
+	return c.VirtualMachineRestore(namespace).Create(ctx, restore, metav1.CreateOptions{})
+}
+
+func (c *Client) GetVirtualMachineRestore(ctx context.Context, namespace, name string) (
+	*snapshotv1alpha1.VirtualMachineRestore, error) {
+	return c.VirtualMachineRestore(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c *Client) DeleteVirtualMachineRestore(ctx context.Context, namespace, name string) error {
+	return c.VirtualMachineRestore(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 }

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -33,10 +33,11 @@ import (
 )
 
 const (
-	StorageClassParamName = "storageClass"
-	VMITimeoutParamName   = "vmiTimeout"
-	NumOfVMsParamName     = "numOfVMs"
-	SkipTeardownParamName = "skipTeardown"
+	StorageClassParamName     = "storageClass"
+	VMITimeoutParamName       = "vmiTimeout"
+	NumOfVMsParamName         = "numOfVMs"
+	SkipTeardownParamName     = "skipTeardown"
+	NumOfDataVolumesParamName = "numOfDataVolumes"
 )
 
 // SkipTeardownMode defines the possible modes for skipping teardown.
@@ -49,31 +50,35 @@ const (
 )
 
 const (
-	VMITimeoutDefault = 3 * time.Minute
-	NumOfVMsDefault   = 10
+	VMITimeoutDefault       = 3 * time.Minute
+	NumOfVMsDefault         = 10
+	NumOfDataVolumesDefault = 0
 )
 
 var (
 	ErrInvalidVMITimeout       = errors.New("invalid VMI timeout")
 	ErrInvalidNumOfVMs         = errors.New("invalid number of VMIs")
 	ErrInvalidSkipTeardownMode = errors.New("invalid skip teardown mode")
+	ErrInvalidNumOfDataVolumes = errors.New("invalid number of data volumes")
 )
 
 type Config struct {
-	PodName      string
-	PodUID       string
-	StorageClass string
-	VMITimeout   time.Duration
-	NumOfVMs     int
-	SkipTeardown SkipTeardownMode
+	PodName          string
+	PodUID           string
+	StorageClass     string
+	VMITimeout       time.Duration
+	NumOfVMs         int
+	SkipTeardown     SkipTeardownMode
+	NumOfDataVolumes int
 }
 
 func New(baseConfig kconfig.Config) (Config, error) {
 	newConfig := Config{
-		PodName:    baseConfig.PodName,
-		PodUID:     baseConfig.PodUID,
-		VMITimeout: VMITimeoutDefault,
-		NumOfVMs:   NumOfVMsDefault,
+		PodName:          baseConfig.PodName,
+		PodUID:           baseConfig.PodUID,
+		VMITimeout:       VMITimeoutDefault,
+		NumOfVMs:         NumOfVMsDefault,
+		NumOfDataVolumes: NumOfDataVolumesDefault,
 	}
 
 	return setOptionalParams(baseConfig, newConfig)
@@ -99,6 +104,13 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 			return Config{}, ErrInvalidNumOfVMs
 		}
 		newConfig.NumOfVMs = numOfVMs
+	}
+	if rawVal, exists := baseConfig.Params[NumOfDataVolumesParamName]; exists && rawVal != "" {
+		numOfDataVolumes, err := strconv.Atoi(rawVal)
+		if err != nil || numOfDataVolumes < 0 || numOfDataVolumes > 10 {
+			return Config{}, ErrInvalidNumOfDataVolumes
+		}
+		newConfig.NumOfDataVolumes = numOfDataVolumes
 	}
 
 	if rawVal, exists := baseConfig.Params[SkipTeardownParamName]; exists && rawVal != "" {

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -97,6 +97,8 @@ func FormatResults(checkupResults status.Results) map[string]string {
 		VMLiveMigrationKey:                           checkupResults.VMLiveMigration,
 		VMHotplugVolumeKey:                           checkupResults.VMHotplugVolume,
 		ConcurrentVMBootKey:                          checkupResults.ConcurrentVMBoot,
+		VMSnapshotKey:                                checkupResults.VMSnapshot,
+		VMRestoreKey:                                 checkupResults.VMRestore,
 	}
 
 	return formattedResults

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -46,6 +46,8 @@ const (
 	VMLiveMigrationKey                           = "vmLiveMigration"
 	VMHotplugVolumeKey                           = "vmHotplugVolume"
 	ConcurrentVMBootKey                          = "concurrentVMBoot"
+	VMSnapshotKey                                = "vmSnapshot"
+	VMRestoreKey                                 = "vmRestore"
 )
 
 type Reporter struct {

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -42,6 +42,8 @@ type Results struct {
 	VMLiveMigration                           string
 	VMHotplugVolume                           string
 	ConcurrentVMBoot                          string
+	VMSnapshot                                string
+	VMRestore                                 string
 }
 
 type Status struct {

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -302,3 +302,4 @@ func getJobConditions() []batchv1.JobCondition {
 
 	return checkupJob.Status.Conditions
 }
+


### PR DESCRIPTION
What this PR does                                                                                                                                     
                                                                                                                                                        
Adds VirtualMachineSnapshot and VirtualMachineRestore support to the storage checkup. The checkup can now take a snapshot of a running VM with multiple disks, validate the snapshot succeeded with the correct indications (Online, GuestAgent), and restore the VM from that snapshot.             
                                                                                                                                                        
Before this PR:                                                                                                                                       
                                                                                                                                                        
The storage checkup tests VM boot, live migration, hotplug volumes, and concurrent boot — but has no coverage for VM snapshot and restore operations. 
VMs are also created with only a single OS disk, which doesn't reflect real-world workloads where VMs typically have additional data disks.

After this PR:

- VMs can be created with configurable additional data disks via a new numOfDataVolumes ConfigMap parameter (default: 0, max: 10)
- The kubeVirtStorageClient interface includes 7 new methods: Create/Get/Delete for VirtualMachineSnapshot, Get for VirtualMachineSnapshotContent, and Create/Get/Delete for VirtualMachineRestore
- Real client implementations and test stubs are provided for all 7 methods - checkVMSnapshot validates: Phase is Succeeded, ReadyToUse is true, Indications contain exactly [Online, GuestAgent], IncludedVolumes matches all VM disks, and ExcludedVolumes is empty
- Results are reported via new vmSnapshot and vmRestore reporter keys

References

https://redhat.atlassian.net/browse/CNV-90395