### PR TITLE
Test/add vmsnapshot + vmsnapshotrestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If you are running this checkup on vanilla Kubernetes (kubeadm, kOps, etc.) rath
 |spec.param.storageClass|Optional storage class to be used instead of the default one|False||
 |spec.param.vmiTimeout|Optional timeout for VMI operations|False|Default is 3m|
 |spec.param.numOfVMs|Optional number of concurrent VMs to boot|False|Default is 10|
+|spec.param.numOfDataVolumes|Optional number of additional data volumes to attach to the VM|False|Default is 0, max is 10|
 |spec.param.skipTeardown|Controls whether the teardown steps should be skipped after checkup completion|False|Available modes: `always`, `onfailure`, `never`. Default is `never`|
 
 
@@ -96,4 +97,6 @@ kubectl get configmap storage-checkup-config -n <target-namespace> -o yaml
 |status.result.vmVolumeClone|VM volume clone type used (efficient or host-assisted) and fallback reason||
 |status.result.vmLiveMigration|VM live-migration||
 |status.result.vmHotplugVolume|VM volume hotplug and unplug||
+|status.result.vmSnapshot|VM snapshot creation and validation||
+|status.result.vmRestore|VM restore from snapshot||
 |status.result.concurrentVMBoot|Concurrent VM boot from a golden image||

--- a/manifests/storage_checkup_permissions.yaml
+++ b/manifests/storage_checkup_permissions.yaml
@@ -19,7 +19,7 @@ rules:
     resources: [ "virtualmachineinstances" ]
     verbs: [ "get" ]
   - apiGroups: [ "subresources.kubevirt.io" ]
-    resources: [ "virtualmachineinstances/addvolume", "virtualmachineinstances/removevolume" ]
+    resources: [ "virtualmachines/stop", "virtualmachineinstances/addvolume", "virtualmachineinstances/removevolume" ]
     verbs: [ "update" ]
   - apiGroups: [ "kubevirt.io" ]
     resources: [ "virtualmachineinstancemigrations" ]
@@ -30,6 +30,9 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "persistentvolumeclaims" ]
     verbs: [ "delete" ]
+  - apiGroups: [ "snapshot.kubevirt.io" ]
+    resources: [ "virtualmachinesnapshots", "virtualmachinerestores" ]
+    verbs: [ "create", "get", "delete" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -856,7 +856,7 @@ func (c *Checkup) checkVMIBoot(ctx context.Context, errStr *string) error {
 	}
 
 	vmName := uniqueVMName()
-	c.vmUnderTest = newVMUnderTest(vmName, c.goldenImagePvc, c.goldenImageSnap, c.checkupConfig, false)
+	c.vmUnderTest = newVMUnderTest(vmName, c.goldenImagePvc, c.goldenImageSnap, c.checkupConfig, c.checkupConfig.NumOfDataVolumes)
 	log.Printf("Creating VM %q", vmName)
 	if _, err := c.client.CreateVirtualMachine(ctx, c.namespace, c.vmUnderTest); err != nil {
 		return fmt.Errorf("failed to create VM: %w", err)
@@ -1070,7 +1070,8 @@ func (c *Checkup) checkConcurrentVMIBoot(ctx context.Context, errStr *string) er
 
 			vmName := uniqueVMName()
 			log.Printf("Creating VM %q", vmName)
-			vm := newVMUnderTest(vmName, c.goldenImagePvc, c.goldenImageSnap, c.checkupConfig, true)
+
+			vm := newVMUnderTest(vmName, c.goldenImagePvc, c.goldenImageSnap, c.checkupConfig, max(c.checkupConfig.NumOfDataVolumes, 1))
 			if _, err := c.client.CreateVirtualMachine(ctx, c.namespace, vm); err != nil {
 				log.Printf("failed to create VM %q: %s", vmName, err)
 				isBootOk = false

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -36,21 +37,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/kiagnose/kubevirt-storage-checkup/pkg/internal/config"
-	"github.com/kiagnose/kubevirt-storage-checkup/pkg/internal/status"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	configv1 "github.com/openshift/api/config/v1"
 
 	kvcorev1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	snapshotv1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
+
+	"github.com/kiagnose/kubevirt-storage-checkup/pkg/internal/config"
+	"github.com/kiagnose/kubevirt-storage-checkup/pkg/internal/status"
 )
 
 type kubeVirtStorageClient interface {
 	CreateVirtualMachine(ctx context.Context, namespace string, vm *kvcorev1.VirtualMachine) (*kvcorev1.VirtualMachine, error)
 	DeleteVirtualMachine(ctx context.Context, namespace, name string) error
+	StopVirtualMachine(ctx context.Context, namespace, name string, stopOptions *kvcorev1.StopOptions) error
 	GetVirtualMachineInstance(ctx context.Context, namespace, name string) (*kvcorev1.VirtualMachineInstance, error)
 	CreateVirtualMachineInstanceMigration(ctx context.Context, namespace string,
 		vmim *kvcorev1.VirtualMachineInstanceMigration) (*kvcorev1.VirtualMachineInstanceMigration, error)
@@ -75,6 +80,14 @@ type kubeVirtStorageClient interface {
 	GetCSIDriver(ctx context.Context, name string) (*storagev1.CSIDriver, error)
 	GetDataSource(ctx context.Context, namespace, name string) (*cdiv1.DataSource, error)
 	GetClusterVersion(ctx context.Context, name string) (*configv1.ClusterVersion, error)
+	CreateVirtualMachineSnapshot(ctx context.Context, namespace string,
+		snapshot *snapshotv1alpha1.VirtualMachineSnapshot) (*snapshotv1alpha1.VirtualMachineSnapshot, error)
+	GetVirtualMachineSnapshot(ctx context.Context, namespace, name string) (*snapshotv1alpha1.VirtualMachineSnapshot, error)
+	DeleteVirtualMachineSnapshot(ctx context.Context, namespace, name string) error
+	CreateVirtualMachineRestore(ctx context.Context, namespace string,
+		restore *snapshotv1alpha1.VirtualMachineRestore) (*snapshotv1alpha1.VirtualMachineRestore, error)
+	GetVirtualMachineRestore(ctx context.Context, namespace, name string) (*snapshotv1alpha1.VirtualMachineRestore, error)
+	DeleteVirtualMachineRestore(ctx context.Context, namespace, name string) error
 }
 
 const (
@@ -102,6 +115,7 @@ const (
 	MessageSkipNoDefaultStorageClass = "Skip check - no default storage class"
 	MessageSkipNoGoldenImage         = "Skip check - no golden image PVC or Snapshot"
 	MessageSkipNoVMI                 = "Skip check - no VMI"
+	MessageSkipNoSnapshot            = "Skip check - no VM snapshot"
 	MessageSkipSingleNode            = "Skip check - single node"
 
 	pollInterval = 5 * time.Second
@@ -147,6 +161,7 @@ func (c *Checkup) Setup(ctx context.Context) error {
 	return nil
 }
 
+//nolint:gocyclo
 func (c *Checkup) Run(ctx context.Context) error {
 	errStr := ""
 
@@ -197,6 +212,14 @@ func (c *Checkup) Run(ctx context.Context) error {
 		return err
 	}
 	if err := c.checkVMIHotplugVolume(ctx, &errStr); err != nil {
+		return err
+	}
+
+	snapshotOK, snapErr := c.checkVMSnapshot(ctx, &errStr)
+	if snapErr != nil {
+		return snapErr
+	}
+	if err := c.checkVMRestore(ctx, snapshotOK, &errStr); err != nil {
 		return err
 	}
 
@@ -810,21 +833,22 @@ func (c *Checkup) Teardown(ctx context.Context) error {
 		return nil
 	}
 	var errs []error
-	collect := func(err error) {
-		if err != nil {
-			errs = append(errs, err)
+	appendTeardownErr := func(action, name string, err error) {
+		if err = ignoreNotFound(err); err != nil {
+			errs = append(errs, fmt.Errorf("%s %q: %w", action, name, err))
 		}
 	}
-	err := c.client.DeleteVirtualMachineRestore(ctx, c.namespace, c.restoreName())
-	collect(teardownErr("delete restore", c.restoreName(), err))
-	err = c.client.DeleteVirtualMachineSnapshot(ctx, c.namespace, c.snapshotName())
-	collect(teardownErr("delete snapshot", c.snapshotName(), err))
-	err = c.client.DeleteVirtualMachine(ctx, c.namespace, c.vmUnderTest.Name)
-	collect(teardownErr("delete VM", c.vmUnderTest.Name, err))
-	err = c.client.DeleteDataVolume(ctx, c.namespace, hotplugVolumeName)
-	collect(teardownErr("delete DataVolume", hotplugVolumeName, err))
-	err = c.client.DeletePersistentVolumeClaim(ctx, c.namespace, hotplugVolumeName)
-	collect(teardownErr("delete PVC", hotplugVolumeName, err))
+
+	appendTeardownErr("delete restore", c.restoreName(),
+		c.client.DeleteVirtualMachineRestore(ctx, c.namespace, c.restoreName()))
+	appendTeardownErr("delete snapshot", c.snapshotName(),
+		c.client.DeleteVirtualMachineSnapshot(ctx, c.namespace, c.snapshotName()))
+	appendTeardownErr("delete VM", c.vmUnderTest.Name,
+		c.client.DeleteVirtualMachine(ctx, c.namespace, c.vmUnderTest.Name))
+	appendTeardownErr("delete DataVolume", hotplugVolumeName,
+		c.client.DeleteDataVolume(ctx, c.namespace, hotplugVolumeName))
+	appendTeardownErr("delete PVC", hotplugVolumeName,
+		c.client.DeletePersistentVolumeClaim(ctx, c.namespace, hotplugVolumeName))
 
 	if err := errors.Join(errs...); err != nil {
 		return fmt.Errorf("teardown: %w", err)
@@ -1151,6 +1175,298 @@ func (c *Checkup) waitForVMIStatus(ctx context.Context, vmName, checkMsg string,
 	return nil
 }
 
+func (c *Checkup) reportVMSnapshotFailure(res string, errStr *string) {
+	log.Print(res)
+	appendSep(&c.results.VMSnapshot, res)
+	appendSep(errStr, res)
+}
+
+func (c *Checkup) waitForVMSnapshotReady(ctx context.Context, errStr *string) (bool, time.Duration) {
+	waitStart := time.Now()
+	log.Printf("Waiting for VMSnapshot %q ready (started at %s)", c.snapshotName(), waitStart.Format(time.RFC3339))
+	err := wait.PollImmediateWithContext(ctx, pollInterval, c.checkupConfig.VMITimeout, func(ctx context.Context) (bool, error) {
+		snapshot, err := c.client.GetVirtualMachineSnapshot(ctx, c.namespace, c.snapshotName())
+		if err != nil {
+			return false, ignoreNotFound(err)
+		}
+		if snapshot.Status != nil && snapshot.Status.ReadyToUse != nil && *snapshot.Status.ReadyToUse {
+			return true, nil
+		}
+		if snapshot.Status != nil && snapshot.Status.Phase == snapshotv1alpha1.Failed {
+			return false, errors.New("snapshot failed")
+		}
+		return false, nil
+	})
+	elapsed := time.Since(waitStart).Round(time.Millisecond)
+	if err != nil {
+		c.reportVMSnapshotFailure(
+			fmt.Sprintf("failed waiting for VMSnapshot %q after %s: %v", c.snapshotName(), elapsed, err),
+			errStr,
+		)
+		return false, 0
+	}
+	log.Printf("VMSnapshot %q ReadyToUse after %s", c.snapshotName(), elapsed)
+	return true, elapsed
+}
+
+func (c *Checkup) validateVMSnapshot(snapshot *snapshotv1alpha1.VirtualMachineSnapshot, errStr *string) bool {
+	if snapshot.Status == nil || snapshot.Status.Phase != snapshotv1alpha1.Succeeded {
+		phase := "has no status"
+		if snapshot.Status != nil {
+			phase = string(snapshot.Status.Phase)
+		}
+		c.reportVMSnapshotFailure(fmt.Sprintf("VMSnapshot %q phase is %s, expected Succeeded", c.snapshotName(), phase), errStr)
+		return false
+	}
+
+	actual := sets.New[snapshotv1alpha1.Indication](snapshot.Status.Indications...)
+	indicationsWithGA := sets.New(
+		snapshotv1alpha1.VMSnapshotOnlineSnapshotIndication,
+		snapshotv1alpha1.VMSnapshotGuestAgentIndication,
+	)
+	indicationsWithoutGA := sets.New(
+		snapshotv1alpha1.VMSnapshotOnlineSnapshotIndication,
+		snapshotv1alpha1.VMSnapshotNoGuestAgentIndication,
+	)
+	if !actual.Equal(indicationsWithGA) && !actual.Equal(indicationsWithoutGA) {
+		c.reportVMSnapshotFailure(
+			fmt.Sprintf("VMSnapshot %q indications %v do not equal expected %v or %v",
+				c.snapshotName(), sets.List(actual), sets.List(indicationsWithGA), sets.List(indicationsWithoutGA)),
+			errStr,
+		)
+		return false
+	}
+
+	if snapshot.Status.SnapshotVolumes == nil {
+		c.reportVMSnapshotFailure(fmt.Sprintf("VMSnapshot %q has no SnapshotVolumes", c.snapshotName()), errStr)
+		return false
+	}
+
+	return true
+}
+
+func (c *Checkup) checkVMSnapshot(ctx context.Context, errStr *string) (bool, error) {
+	log.Print("checkVMSnapshot")
+
+	if c.vmUnderTest == nil {
+		log.Print(MessageSkipNoVMI)
+		c.results.VMSnapshot = MessageSkipNoVMI
+		return false, nil
+	}
+	vmSnapshot := &snapshotv1alpha1.VirtualMachineSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.snapshotName(),
+		},
+		Spec: snapshotv1alpha1.VirtualMachineSnapshotSpec{
+			Source: corev1.TypedLocalObjectReference{
+				APIGroup: new("kubevirt.io"),
+				Kind:     "VirtualMachine",
+				Name:     c.vmUnderTest.Name,
+			},
+		},
+	}
+
+	log.Printf("Creating VMSnapshot %q at %s", c.snapshotName(), time.Now().Format(time.RFC3339))
+	if _, err := c.client.CreateVirtualMachineSnapshot(ctx, c.namespace, vmSnapshot); err != nil {
+		return false, fmt.Errorf("failed to create VMSnapshot: %w", err)
+	}
+	log.Printf("VMSnapshot %q created", c.snapshotName())
+
+	ready, elapsed := c.waitForVMSnapshotReady(ctx, errStr)
+	if !ready {
+		return false, nil
+	}
+
+	snapshot, err := c.client.GetVirtualMachineSnapshot(ctx, c.namespace, c.snapshotName())
+	if err != nil {
+		return false, fmt.Errorf("failed to get VMSnapshot %q: %w", c.snapshotName(), err)
+	}
+	if !c.validateVMSnapshot(snapshot, errStr) {
+		return false, nil
+	}
+
+	log.Printf("VMSnapshot for VM %q succeeded, CreationTime=%s, ReadyToUse=%s",
+		c.vmUnderTest.Name, formatMetaTime(snapshot.Status.CreationTime), formatBoolPtr(snapshot.Status.ReadyToUse))
+	appendSep(&c.results.VMSnapshot, fmt.Sprintf("VMSnapshot name: %s", c.snapshotName()))
+	appendSep(&c.results.VMSnapshot, fmt.Sprintf("VMSnapshot for VM %q succeeded", c.vmUnderTest.Name))
+	appendSep(&c.results.VMSnapshot, fmt.Sprintf("Creation time: %s", formatMetaTime(snapshot.Status.CreationTime)))
+	appendSep(&c.results.VMSnapshot, fmt.Sprintf("Creation duration: %s",
+		snapshot.Status.CreationTime.Time.Sub(snapshot.CreationTimestamp.Time).Round(time.Millisecond)))
+	appendSep(&c.results.VMSnapshot, fmt.Sprintf("Ready duration: %s", elapsed))
+	appendSep(&c.results.VMSnapshot, fmt.Sprintf("ReadyToUse=%s", formatBoolPtr(snapshot.Status.ReadyToUse)))
+	appendSep(&c.results.VMSnapshot, fmt.Sprintf("Indications: %v", snapshot.Status.Indications))
+	appendSep(&c.results.VMSnapshot, fmt.Sprintf("Included volumes: %v", snapshot.Status.SnapshotVolumes.IncludedVolumes))
+	if len(snapshot.Status.SnapshotVolumes.ExcludedVolumes) > 0 {
+		appendSep(&c.results.VMSnapshot, fmt.Sprintf("Excluded volumes: %v", snapshot.Status.SnapshotVolumes.ExcludedVolumes))
+	}
+	return true, nil
+}
+
+// stopVMUnderTest stops the VM via the KubeVirt Stop subresource and waits until the VMI is gone.
+// Required before VirtualMachineRestore (v1alpha1 has no StopTarget policy).
+func (c *Checkup) stopVMUnderTest(ctx context.Context) error {
+	if c.vmUnderTest == nil {
+		return nil
+	}
+	vmName := c.vmUnderTest.Name
+	log.Printf("Stopping VM %q before restore", vmName)
+
+	if err := c.client.StopVirtualMachine(ctx, c.namespace, vmName, &kvcorev1.StopOptions{}); err != nil {
+		return fmt.Errorf("failed to stop VM %q: %w", vmName, err)
+	}
+
+	log.Printf("Waiting for VMI %q to disappear", vmName)
+	if err := wait.PollImmediateWithContext(ctx, pollInterval, c.checkupConfig.VMITimeout, func(ctx context.Context) (bool, error) {
+		_, err := c.client.GetVirtualMachineInstance(ctx, c.namespace, vmName)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	}); err != nil {
+		return fmt.Errorf("failed waiting for VMI %q to stop: %w", vmName, err)
+	}
+
+	log.Printf("VM %q stopped", vmName)
+	return nil
+}
+
+func (c *Checkup) checkVMRestore(ctx context.Context, snapshotOK bool, errStr *string) error {
+	log.Print("checkVMRestore")
+
+	if c.vmUnderTest == nil {
+		log.Print(MessageSkipNoVMI)
+		c.results.VMRestore = MessageSkipNoVMI
+		return nil
+	}
+	if !snapshotOK {
+		log.Print(MessageSkipNoSnapshot)
+		c.results.VMRestore = MessageSkipNoSnapshot
+		return nil
+	}
+
+	if err := c.stopVMUnderTest(ctx); err != nil {
+		return fmt.Errorf("failed to stop VM before restore: %w", err)
+	}
+
+	vmRestore := &snapshotv1alpha1.VirtualMachineRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.restoreName(),
+		},
+		Spec: snapshotv1alpha1.VirtualMachineRestoreSpec{
+			Target: corev1.TypedLocalObjectReference{
+				APIGroup: new("kubevirt.io"),
+				Kind:     "VirtualMachine",
+				Name:     c.vmUnderTest.Name,
+			},
+			VirtualMachineSnapshotName: c.snapshotName(),
+		},
+	}
+
+	log.Printf("Creating VMRestore %q at %s", c.restoreName(), time.Now().Format(time.RFC3339))
+	if _, err := c.client.CreateVirtualMachineRestore(ctx, c.namespace, vmRestore); err != nil {
+		return fmt.Errorf("failed to create VMRestore: %w", err)
+	}
+	log.Printf("VMRestore %q created", c.restoreName())
+
+	complete, elapsed := c.waitForVMRestoreComplete(ctx, errStr)
+	if !complete {
+		return nil
+	}
+
+	restore, err := c.client.GetVirtualMachineRestore(ctx, c.namespace, c.restoreName())
+	if err != nil {
+		return fmt.Errorf("failed to get VMRestore %q: %w", c.restoreName(), err)
+	}
+	if !c.validateVMRestore(restore, errStr) {
+		return nil
+	}
+
+	log.Printf("VMRestore for VM %q succeeded (RestoreTime=%s, Complete=%s)",
+		c.vmUnderTest.Name, formatMetaTime(restore.Status.RestoreTime), formatBoolPtr(restore.Status.Complete))
+
+	appendSep(&c.results.VMRestore, fmt.Sprintf("VMRestore name: %s", c.restoreName()))
+	appendSep(&c.results.VMRestore, fmt.Sprintf("VMRestore for VM %q succeeded", c.vmUnderTest.Name))
+	appendSep(&c.results.VMRestore, fmt.Sprintf("Restore time: %s", formatMetaTime(restore.Status.RestoreTime)))
+	appendSep(&c.results.VMRestore, fmt.Sprintf("Complete duration: %s", elapsed))
+	appendSep(&c.results.VMRestore, fmt.Sprintf("Complete=%s", formatBoolPtr(restore.Status.Complete)))
+	return nil
+}
+
+func (c *Checkup) reportVMRestoreFailure(res string, errStr *string) {
+	log.Print(res)
+	appendSep(&c.results.VMRestore, res)
+	appendSep(errStr, res)
+}
+
+func (c *Checkup) waitForVMRestoreComplete(ctx context.Context, errStr *string) (bool, time.Duration) {
+	waitStart := time.Now()
+	log.Printf("Waiting for VMRestore %q complete (started at %s)", c.restoreName(), waitStart.Format(time.RFC3339))
+	err := wait.PollImmediateWithContext(ctx, pollInterval, c.checkupConfig.VMITimeout, func(ctx context.Context) (bool, error) {
+		restore, err := c.client.GetVirtualMachineRestore(ctx, c.namespace, c.restoreName())
+		if err != nil {
+			return false, ignoreNotFound(err)
+		}
+		if restore.Status != nil && restore.Status.Complete != nil && *restore.Status.Complete {
+			return true, nil
+		}
+		return false, nil
+	})
+	elapsed := time.Since(waitStart).Round(time.Millisecond)
+	if err != nil {
+		c.reportVMRestoreFailure(
+			fmt.Sprintf("failed waiting for VMRestore %q after %s: %v", c.restoreName(), elapsed, err),
+			errStr,
+		)
+		return false, 0
+	}
+	log.Printf("VMRestore %q complete after %s", c.restoreName(), elapsed)
+	return true, elapsed
+}
+
+func (c *Checkup) validateVMRestore(restore *snapshotv1alpha1.VirtualMachineRestore, errStr *string) bool {
+	if restore.Status == nil {
+		c.reportVMRestoreFailure(fmt.Sprintf("VMRestore %q has no status", c.restoreName()), errStr)
+		return false
+	}
+	if restore.Status.Complete == nil || !*restore.Status.Complete {
+		c.reportVMRestoreFailure(fmt.Sprintf("VMRestore %q is not complete", c.restoreName()), errStr)
+		return false
+	}
+	if len(restore.Status.Restores) == 0 {
+		c.reportVMRestoreFailure(fmt.Sprintf("VMRestore %q has no volume restores", c.restoreName()), errStr)
+		return false
+	}
+
+	expectedVolumes := sets.New[string]()
+	for _, vol := range c.vmUnderTest.Spec.Template.Spec.Volumes {
+		expectedVolumes.Insert(vol.Name)
+	}
+	restoredVolumes := sets.New[string]()
+	for _, vr := range restore.Status.Restores {
+		restoredVolumes.Insert(vr.VolumeName)
+	}
+	if !expectedVolumes.Equal(restoredVolumes.Intersection(expectedVolumes)) {
+		c.reportVMRestoreFailure(
+			fmt.Sprintf("VMRestore %q restored volumes %v do not contain all expected %v",
+				c.restoreName(), sets.List(restoredVolumes), sets.List(expectedVolumes)),
+			errStr,
+		)
+		return false
+	}
+	return true
+}
+
+func (c *Checkup) snapshotName() string {
+	return fmt.Sprintf("snapshot-%s", c.vmUnderTest.Name)
+}
+
+func (c *Checkup) restoreName() string {
+	return fmt.Sprintf("restore-%s", c.vmUnderTest.Name)
+}
+
 func appendSep(s *string, appended string) {
 	if s == nil {
 		return
@@ -1160,6 +1476,20 @@ func appendSep(s *string, appended string) {
 		return
 	}
 	*s = *s + "\n" + appended
+}
+
+func formatMetaTime(t *metav1.Time) string {
+	if t == nil {
+		return "<nil>"
+	}
+	return t.UTC().Format("15:04:05 UTC")
+}
+
+func formatBoolPtr(b *bool) string {
+	if b == nil {
+		return "<nil>"
+	}
+	return strconv.FormatBool(*b)
 }
 
 // FIXME: use slices.contains instead
@@ -1178,11 +1508,4 @@ func ignoreNotFound(err error) error {
 		return nil
 	}
 	return err
-}
-
-func teardownErr(action, name string, err error) error {
-	if err = ignoreNotFound(err); err != nil {
-		return fmt.Errorf("%s %q: %w", action, name, err)
-	}
-	return nil
 }

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -809,19 +809,26 @@ func (c *Checkup) Teardown(ctx context.Context) error {
 	if c.vmUnderTest == nil {
 		return nil
 	}
-
-	if err := c.client.DeleteVirtualMachine(ctx, c.namespace, c.vmUnderTest.Name); ignoreNotFound(err) != nil {
-		return fmt.Errorf("teardown: %v", err)
+	var errs []error
+	collect := func(err error) {
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
+	err := c.client.DeleteVirtualMachineRestore(ctx, c.namespace, c.restoreName())
+	collect(teardownErr("delete restore", c.restoreName(), err))
+	err = c.client.DeleteVirtualMachineSnapshot(ctx, c.namespace, c.snapshotName())
+	collect(teardownErr("delete snapshot", c.snapshotName(), err))
+	err = c.client.DeleteVirtualMachine(ctx, c.namespace, c.vmUnderTest.Name)
+	collect(teardownErr("delete VM", c.vmUnderTest.Name, err))
+	err = c.client.DeleteDataVolume(ctx, c.namespace, hotplugVolumeName)
+	collect(teardownErr("delete DataVolume", hotplugVolumeName, err))
+	err = c.client.DeletePersistentVolumeClaim(ctx, c.namespace, hotplugVolumeName)
+	collect(teardownErr("delete PVC", hotplugVolumeName, err))
 
-	if err := c.client.DeleteDataVolume(ctx, c.namespace, hotplugVolumeName); ignoreNotFound(err) != nil {
-		return fmt.Errorf("teardown: %v", err)
+	if err := errors.Join(errs...); err != nil {
+		return fmt.Errorf("teardown: %w", err)
 	}
-
-	if err := c.client.DeletePersistentVolumeClaim(ctx, c.namespace, hotplugVolumeName); ignoreNotFound(err) != nil {
-		return fmt.Errorf("teardown: %v", err)
-	}
-
 	return nil
 }
 
@@ -1170,4 +1177,11 @@ func ignoreNotFound(err error) error {
 		return nil
 	}
 	return err
+}
+
+func teardownErr(action, name string, err error) error {
+	if err = ignoreNotFound(err); err != nil {
+		return fmt.Errorf("%s %q: %w", action, name, err)
+	}
+	return nil
 }

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	configv1 "github.com/openshift/api/config/v1"
@@ -42,11 +43,12 @@ import (
 	"github.com/kiagnose/kubevirt-storage-checkup/pkg/internal/checkup"
 	"github.com/kiagnose/kubevirt-storage-checkup/pkg/internal/config"
 	"github.com/kiagnose/kubevirt-storage-checkup/pkg/internal/reporter"
+
+	snapshotv1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 )
 
 const (
 	testNamespace = "target-ns"
-	testNode      = "test-node"
 )
 
 var (
@@ -87,6 +89,8 @@ var tests = map[string]struct {
 	clientConfig    clientConfig
 	expectedResults map[string]string
 	expectedErr     string
+	resultsContains bool
+	vmiTimeout      time.Duration
 }{
 	"noStorageClasses": {
 		clientConfig: clientConfig{noStorageClasses: true, expectNoVMI: true},
@@ -181,6 +185,29 @@ var tests = map[string]struct {
 		expectedResults: map[string]string{reporter.VMLiveMigrationKey: "failed waiting for VMI \"%s\" migration completed: migration failed"},
 		expectedErr:     "migration failed",
 	},
+	"snapshotFails": {
+		clientConfig: clientConfig{failSnapshot: true},
+		expectedResults: map[string]string{
+			reporter.VMSnapshotKey: `failed waiting for VMSnapshot "snapshot-%s" after 0s: snapshot failed`,
+			reporter.VMRestoreKey:  checkup.MessageSkipNoSnapshot,
+		},
+		expectedErr: `snapshot failed`,
+	},
+	"restoreFails": {
+		clientConfig: clientConfig{failRestore: true},
+		expectedResults: map[string]string{
+			reporter.VMRestoreKey: `VMRestore "restore-%s" has no volume restores`,
+		},
+		expectedErr: `has no volume restores`,
+	},
+	"stopFails": {
+		clientConfig: clientConfig{failStop: true},
+		expectedResults: map[string]string{
+			reporter.VMSnapshotKey: fmt.Sprintf("VMSnapshot name: snapshot-%%s"),
+		},
+		resultsContains: true,
+		expectedErr:     "failed to stop VM",
+	},
 	"skipMigrationOnSingleNode": {
 		clientConfig:    clientConfig{singleNode: true},
 		expectedResults: map[string]string{reporter.VMLiveMigrationKey: "Skip check - single node"},
@@ -193,6 +220,9 @@ func TestCheckupShouldReturnErrorWhen(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			testClient := newClientStub(tc.clientConfig)
 			testConfig := newTestConfig()
+			if tc.vmiTimeout > 0 {
+				testConfig.VMITimeout = tc.vmiTimeout
+			}
 
 			testCheckup := checkup.New(testClient, testNamespace, testConfig)
 
@@ -207,10 +237,16 @@ func TestCheckupShouldReturnErrorWhen(t *testing.T) {
 				checkOwnerRef(t, testClient)
 			}
 
-			expectedResults := fullExpectedResults(vmiUnderTestName, tc.expectedResults)
 			actualResults := reporter.FormatResults(testCheckup.Results())
-
-			assert.Equal(t, expectedResults, actualResults)
+			if tc.resultsContains {
+				for key, substr := range tc.expectedResults {
+					substr = strings.ReplaceAll(substr, "%s", vmiUnderTestName)
+					assert.Contains(t, actualResults[key], substr, "key %s", key)
+				}
+			} else {
+				expectedResults := fullExpectedResults(vmiUnderTestName, tc.expectedResults)
+				assert.Equal(t, expectedResults, actualResults)
+			}
 			if tc.expectedErr != "" {
 				assert.ErrorContains(t, err, tc.expectedErr)
 			} else {
@@ -237,9 +273,7 @@ func fullExpectedResults(vmiUnderTestName string, expectedResults map[string]str
 		expectedResultsNoVMI(fullResults)
 	}
 	for key, expectedResult := range expectedResults {
-		if strings.Contains(expectedResult, "%s") {
-			expectedResult = fmt.Sprintf(expectedResult, vmiUnderTestName)
-		}
+		expectedResult = strings.ReplaceAll(expectedResult, "%s", vmiUnderTestName)
 		fullResults[key] = expectedResult
 	}
 	return fullResults
@@ -248,6 +282,8 @@ func fullExpectedResults(vmiUnderTestName string, expectedResults map[string]str
 func expectedResultsNoVMI(expectedResults map[string]string) {
 	expectedResults[reporter.VMHotplugVolumeKey] = checkup.MessageSkipNoVMI
 	expectedResults[reporter.VMLiveMigrationKey] = checkup.MessageSkipNoVMI
+	expectedResults[reporter.VMSnapshotKey] = checkup.MessageSkipNoVMI
+	expectedResults[reporter.VMRestoreKey] = checkup.MessageSkipNoVMI
 	expectedResults[reporter.VMVolumeCloneKey] = ""
 }
 
@@ -273,6 +309,23 @@ func successfulRunResults(vmiUnderTestName string) map[string]string {
 		reporter.VMHotplugVolumeKey: fmt.Sprintf("VMI %q hotplug volume ready\nVMI %q hotplug volume removed",
 			vmiUnderTestName, vmiUnderTestName),
 		reporter.ConcurrentVMBootKey: "Boot completed on all VMs on time",
+		reporter.VMSnapshotKey: strings.Join([]string{
+			fmt.Sprintf("VMSnapshot name: %s", "snapshot-"+vmiUnderTestName),
+			fmt.Sprintf("VMSnapshot for VM %q succeeded", vmiUnderTestName),
+			"Creation time: 03:04:05 UTC",
+			"Creation duration: 0s",
+			"Ready duration: 0s",
+			"ReadyToUse=true",
+			"Indications: [Online GuestAgent]",
+			fmt.Sprintf("Included volumes: [%s-dv]", vmiUnderTestName),
+		}, "\n"),
+		reporter.VMRestoreKey: strings.Join([]string{
+			fmt.Sprintf("VMRestore name: %s", "restore-"+vmiUnderTestName),
+			fmt.Sprintf("VMRestore for VM %q succeeded", vmiUnderTestName),
+			"Restore time: 03:05:06 UTC",
+			"Complete duration: 0s",
+			"Complete=true",
+		}, "\n"),
 	}
 }
 
@@ -294,12 +347,17 @@ type clientConfig struct {
 	expectNoVMI                       bool
 	cloneFallback                     bool
 	failMigration                     bool
+	failSnapshot                      bool
+	failRestore                       bool
+	failStop                          bool
 	singleNode                        bool
 }
 
 type clientStub struct {
 	createdVMs        map[string]*kvcorev1.VirtualMachine
 	createdVMIs       map[string]*kvcorev1.VirtualMachineInstance
+	createdSnapshots  map[string]*snapshotv1alpha1.VirtualMachineSnapshot
+	createdRestores   map[string]*snapshotv1alpha1.VirtualMachineRestore
 	vmCreationFailure error
 	vmDeletionFailure error
 	vmiGetFailure     error
@@ -308,9 +366,11 @@ type clientStub struct {
 
 func newClientStub(clientConfig clientConfig) *clientStub {
 	return &clientStub{
-		createdVMs:   map[string]*kvcorev1.VirtualMachine{},
-		createdVMIs:  map[string]*kvcorev1.VirtualMachineInstance{},
-		clientConfig: clientConfig,
+		createdVMs:       map[string]*kvcorev1.VirtualMachine{},
+		createdVMIs:      map[string]*kvcorev1.VirtualMachineInstance{},
+		createdSnapshots: map[string]*snapshotv1alpha1.VirtualMachineSnapshot{},
+		createdRestores:  map[string]*snapshotv1alpha1.VirtualMachineRestore{},
+		clientConfig:     clientConfig,
 	}
 }
 
@@ -352,6 +412,23 @@ func (cs *clientStub) CreateVirtualMachine(ctx context.Context, namespace string
 	return vm, nil
 }
 
+func (cs *clientStub) StopVirtualMachine(ctx context.Context, namespace, name string, stopOptions *kvcorev1.StopOptions) error {
+	if cs.failStop {
+		return fmt.Errorf("failed to stop VM")
+	}
+	vmFullName := objectFullName(namespace, name)
+	vm, exist := cs.createdVMs[vmFullName]
+	if !exist {
+		return errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachines"}, name)
+	}
+	// Mimic Stop on Always: KubeVirt moves to Halted and removes the VMI.
+	runStrategy := kvcorev1.RunStrategyHalted
+	vm.Spec.RunStrategy = &runStrategy
+	vm.Spec.Running = nil
+	delete(cs.createdVMIs, vmFullName)
+	return nil
+}
+
 func (cs *clientStub) DeleteVirtualMachine(ctx context.Context, namespace, name string) error {
 	if cs.vmDeletionFailure != nil {
 		return cs.vmDeletionFailure
@@ -360,9 +437,6 @@ func (cs *clientStub) DeleteVirtualMachine(ctx context.Context, namespace, name 
 	vmFullName := objectFullName(namespace, name)
 	if _, exist := cs.createdVMs[vmFullName]; !exist {
 		return errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachines"}, name)
-	}
-	if _, exist := cs.createdVMIs[vmFullName]; !exist {
-		return errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstances"}, name)
 	}
 
 	if !cs.skipDeletion {
@@ -770,6 +844,140 @@ func (cs *clientStub) GetClusterVersion(ctx context.Context, name string) (*conf
 	}
 
 	return ver, nil
+}
+
+func (cs *clientStub) CreateVirtualMachineSnapshot(ctx context.Context, namespace string,
+	snapshot *snapshotv1alpha1.VirtualMachineSnapshot) (*snapshotv1alpha1.VirtualMachineSnapshot, error) {
+	snapshot.Namespace = namespace
+	snapshotFullName := objectFullName(snapshot.Namespace, snapshot.Name)
+	cs.createdSnapshots[snapshotFullName] = snapshot
+	vmFullName := objectFullName(namespace, snapshot.Spec.Source.Name)
+	vm, exists := cs.createdVMs[vmFullName]
+	if !exists {
+		return nil, fmt.Errorf("virtual machine %s not found", vmFullName)
+	}
+	var includedVolumes []string
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		includedVolumes = append(includedVolumes, volume.Name)
+	}
+
+	readyToUse := true
+	creationTime := metav1.Time{Time: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)}
+	snapshot.CreationTimestamp = creationTime
+
+	phase := snapshotv1alpha1.Succeeded
+	if cs.failSnapshot {
+		phase = snapshotv1alpha1.Failed
+		readyToUse = false
+	}
+
+	indications := []snapshotv1alpha1.Indication{
+		snapshotv1alpha1.VMSnapshotOnlineSnapshotIndication,
+		snapshotv1alpha1.VMSnapshotGuestAgentIndication,
+	}
+
+	snapshotVolumes := &snapshotv1alpha1.SnapshotVolumesLists{
+		IncludedVolumes: includedVolumes,
+		ExcludedVolumes: []string{},
+	}
+
+	snapshot.Status = &snapshotv1alpha1.VirtualMachineSnapshotStatus{
+		Phase:           phase,
+		ReadyToUse:      &readyToUse,
+		CreationTime:    &creationTime,
+		Indications:     indications,
+		SnapshotVolumes: snapshotVolumes,
+	}
+	return snapshot, nil
+}
+
+func (cs *clientStub) GetVirtualMachineSnapshot(ctx context.Context, namespace,
+	name string) (*snapshotv1alpha1.VirtualMachineSnapshot, error) {
+	snapshotFullName := objectFullName(namespace, name)
+	snapshot, exists := cs.createdSnapshots[snapshotFullName]
+	if !exists {
+		return nil, errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachinesnapshots"}, name)
+	}
+	return snapshot, nil
+}
+
+func (cs *clientStub) DeleteVirtualMachineSnapshot(ctx context.Context, namespace, name string) error {
+	snapshotFullName := objectFullName(namespace, name)
+	delete(cs.createdSnapshots, snapshotFullName)
+	return nil
+}
+
+func (cs *clientStub) CreateVirtualMachineRestore(ctx context.Context, namespace string,
+	restore *snapshotv1alpha1.VirtualMachineRestore) (*snapshotv1alpha1.VirtualMachineRestore, error) {
+	restore.Namespace = namespace
+	// 1. snapshot
+	snapshotFullName := objectFullName(namespace, restore.Spec.VirtualMachineSnapshotName)
+	snapshot, exists := cs.createdSnapshots[snapshotFullName]
+	if !exists {
+		return nil, errors.NewNotFound(schema.GroupResource{Group: "snapshot.kubevirt.io", Resource: "virtualmachinesnapshots"},
+			restore.Spec.VirtualMachineSnapshotName)
+	}
+	// 2. VM from snapshot source
+	vmFullName := objectFullName(namespace, snapshot.Spec.Source.Name)
+	vm, exists := cs.createdVMs[vmFullName]
+	if !exists {
+		return nil, fmt.Errorf("virtual machine %s not found", vmFullName)
+	}
+	// 3. build status from VM disks
+	var restores []snapshotv1alpha1.VolumeRestore
+	for _, vol := range vm.Spec.Template.Spec.Volumes {
+		vsName := fmt.Sprintf("vs-%s", vol.Name)
+		restores = append(restores, snapshotv1alpha1.VolumeRestore{
+			VolumeName:                vol.Name,
+			PersistentVolumeClaimName: vol.Name,
+			VolumeSnapshotName:        vsName,
+		})
+	}
+	var deletedDVs []string
+	for _, dvt := range vm.Spec.DataVolumeTemplates {
+		deletedDVs = append(deletedDVs, dvt.Name)
+	}
+
+	complete := true
+	restoreTime := metav1.Time{Time: time.Date(2026, 1, 2, 3, 5, 6, 0, time.UTC)}
+	if cs.failRestore {
+		restores = nil
+	}
+
+	restore.Status = &snapshotv1alpha1.VirtualMachineRestoreStatus{
+		Complete:           &complete,
+		RestoreTime:        &restoreTime,
+		Restores:           restores,
+		DeletedDataVolumes: deletedDVs,
+		Conditions: []snapshotv1alpha1.Condition{
+			{
+				Type:   snapshotv1alpha1.ConditionReady,
+				Status: corev1.ConditionTrue,
+			},
+			{
+				Type:   snapshotv1alpha1.ConditionProgressing,
+				Status: corev1.ConditionFalse,
+			},
+		},
+	}
+	cs.createdRestores[objectFullName(namespace, restore.Name)] = restore
+	return restore, nil
+}
+
+func (cs *clientStub) GetVirtualMachineRestore(ctx context.Context, namespace,
+	name string) (*snapshotv1alpha1.VirtualMachineRestore, error) {
+	restoreFullName := objectFullName(namespace, name)
+	restore, exists := cs.createdRestores[restoreFullName]
+	if !exists {
+		return nil, errors.NewNotFound(schema.GroupResource{Group: "snapshot.kubevirt.io", Resource: "virtualmachinerestores"}, name)
+	}
+	return restore, nil
+}
+
+func (cs *clientStub) DeleteVirtualMachineRestore(ctx context.Context, namespace, name string) error {
+	restoreFullName := objectFullName(namespace, name)
+	delete(cs.createdRestores, restoreFullName)
+	return nil
 }
 
 func (cs *clientStub) ListCDIs(ctx context.Context) (*cdiv1.CDIList, error) {

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -38,7 +38,7 @@ const (
 )
 
 func newVMUnderTest(name string, pvc *corev1.PersistentVolumeClaim, snap *snapshotv1.VolumeSnapshot,
-	checkupConfig config.Config, addBlankDataVolume bool) *kvcorev1.VirtualMachine {
+	checkupConfig config.Config, numBlankDataVolumes int) *kvcorev1.VirtualMachine {
 	dvName := getVMDvName(name)
 	dvOpts := []vmi.DataVolumeOption{}
 
@@ -60,16 +60,23 @@ func newVMUnderTest(name string, pvc *corev1.PersistentVolumeClaim, snap *snapsh
 		vmi.WithOwnerReference(checkupConfig.PodName, checkupConfig.PodUID),
 	}
 
-	if addBlankDataVolume {
-		blankDvName := fmt.Sprintf("%s-blank", dvName)
-		dvOpts := []vmi.DataVolumeOption{vmi.WithDataVolumeBlankSource()}
-		if checkupConfig.StorageClass != "" {
-			dvOpts = append(dvOpts, vmi.WithDataVolumeStorageClass(checkupConfig.StorageClass))
-		}
-		optionsToApply = append(optionsToApply, vmi.WithDataVolume(blankDvName, dvOpts...))
-	}
+	optionsToApply = append(optionsToApply,
+		blankDataVolumeOptions(dvName, numBlankDataVolumes, checkupConfig.StorageClass)...)
 
 	return vmi.NewVM(name, optionsToApply...)
+}
+
+func blankDataVolumeOptions(dvName string, count int, storageClass string) []vmi.Option {
+	opts := make([]vmi.Option, 0, count)
+	for i := 1; i <= count; i++ {
+		blankDvName := fmt.Sprintf("%s-data-%d", dvName, i)
+		dvOpts := []vmi.DataVolumeOption{vmi.WithDataVolumeBlankSource()}
+		if storageClass != "" {
+			dvOpts = append(dvOpts, vmi.WithDataVolumeStorageClass(storageClass))
+		}
+		opts = append(opts, vmi.WithDataVolume(blankDvName, dvOpts...))
+	}
+	return opts
 }
 
 func getVMDvName(vmName string) string {

--- a/pkg/internal/client/client.go
+++ b/pkg/internal/client/client.go
@@ -34,6 +34,8 @@ import (
 	kvcorev1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	snapshotv1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 )
 
 type Client struct {
@@ -67,6 +69,10 @@ func (c *Client) CreateVirtualMachine(ctx context.Context, namespace string, vm 
 
 func (c *Client) DeleteVirtualMachine(ctx context.Context, namespace, name string) error {
 	return c.VirtualMachine(namespace).Delete(ctx, name, &metav1.DeleteOptions{})
+}
+
+func (c *Client) StopVirtualMachine(ctx context.Context, namespace, name string, stopOptions *kvcorev1.StopOptions) error {
+	return c.VirtualMachine(namespace).Stop(ctx, name, stopOptions)
 }
 
 func (c *Client) GetVirtualMachineInstance(ctx context.Context, namespace, name string) (*kvcorev1.VirtualMachineInstance, error) {
@@ -158,4 +164,32 @@ func (c *Client) GetDataSource(ctx context.Context, namespace, name string) (*cd
 
 func (c *Client) GetClusterVersion(ctx context.Context, name string) (*configv1.ClusterVersion, error) {
 	return c.ClusterVersions().Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c *Client) CreateVirtualMachineSnapshot(ctx context.Context, namespace string,
+	snapshot *snapshotv1alpha1.VirtualMachineSnapshot) (*snapshotv1alpha1.VirtualMachineSnapshot, error) {
+	return c.VirtualMachineSnapshot(namespace).Create(ctx, snapshot, metav1.CreateOptions{})
+}
+
+func (c *Client) GetVirtualMachineSnapshot(ctx context.Context, namespace, name string) (
+	*snapshotv1alpha1.VirtualMachineSnapshot, error) {
+	return c.VirtualMachineSnapshot(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c *Client) DeleteVirtualMachineSnapshot(ctx context.Context, namespace, name string) error {
+	return c.VirtualMachineSnapshot(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+}
+
+func (c *Client) CreateVirtualMachineRestore(ctx context.Context, namespace string,
+	restore *snapshotv1alpha1.VirtualMachineRestore) (*snapshotv1alpha1.VirtualMachineRestore, error) {
+	return c.VirtualMachineRestore(namespace).Create(ctx, restore, metav1.CreateOptions{})
+}
+
+func (c *Client) GetVirtualMachineRestore(ctx context.Context, namespace, name string) (
+	*snapshotv1alpha1.VirtualMachineRestore, error) {
+	return c.VirtualMachineRestore(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c *Client) DeleteVirtualMachineRestore(ctx context.Context, namespace, name string) error {
+	return c.VirtualMachineRestore(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 }

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -33,10 +33,11 @@ import (
 )
 
 const (
-	StorageClassParamName = "storageClass"
-	VMITimeoutParamName   = "vmiTimeout"
-	NumOfVMsParamName     = "numOfVMs"
-	SkipTeardownParamName = "skipTeardown"
+	StorageClassParamName     = "storageClass"
+	VMITimeoutParamName       = "vmiTimeout"
+	NumOfVMsParamName         = "numOfVMs"
+	SkipTeardownParamName     = "skipTeardown"
+	NumOfDataVolumesParamName = "numOfDataVolumes"
 )
 
 // SkipTeardownMode defines the possible modes for skipping teardown.
@@ -49,36 +50,41 @@ const (
 )
 
 const (
-	VMITimeoutDefault = 3 * time.Minute
-	NumOfVMsDefault   = 10
+	VMITimeoutDefault       = 3 * time.Minute
+	NumOfVMsDefault         = 10
+	NumOfDataVolumesDefault = 0
 )
 
 var (
 	ErrInvalidVMITimeout       = errors.New("invalid VMI timeout")
 	ErrInvalidNumOfVMs         = errors.New("invalid number of VMIs")
 	ErrInvalidSkipTeardownMode = errors.New("invalid skip teardown mode")
+	ErrInvalidNumOfDataVolumes = errors.New("invalid number of data volumes")
 )
 
 type Config struct {
-	PodName      string
-	PodUID       string
-	StorageClass string
-	VMITimeout   time.Duration
-	NumOfVMs     int
-	SkipTeardown SkipTeardownMode
+	PodName          string
+	PodUID           string
+	StorageClass     string
+	VMITimeout       time.Duration
+	NumOfVMs         int
+	SkipTeardown     SkipTeardownMode
+	NumOfDataVolumes int
 }
 
 func New(baseConfig kconfig.Config) (Config, error) {
 	newConfig := Config{
-		PodName:    baseConfig.PodName,
-		PodUID:     baseConfig.PodUID,
-		VMITimeout: VMITimeoutDefault,
-		NumOfVMs:   NumOfVMsDefault,
+		PodName:          baseConfig.PodName,
+		PodUID:           baseConfig.PodUID,
+		VMITimeout:       VMITimeoutDefault,
+		NumOfVMs:         NumOfVMsDefault,
+		NumOfDataVolumes: NumOfDataVolumesDefault,
 	}
 
 	return setOptionalParams(baseConfig, newConfig)
 }
 
+//nolint:gocyclo // flat sequence of independent optional-param parsers
 func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, error) {
 	var err error
 
@@ -99,6 +105,13 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 			return Config{}, ErrInvalidNumOfVMs
 		}
 		newConfig.NumOfVMs = numOfVMs
+	}
+	if rawVal, exists := baseConfig.Params[NumOfDataVolumesParamName]; exists && rawVal != "" {
+		numOfDataVolumes, err := strconv.Atoi(rawVal)
+		if err != nil || numOfDataVolumes < 0 || numOfDataVolumes > 10 {
+			return Config{}, ErrInvalidNumOfDataVolumes
+		}
+		newConfig.NumOfDataVolumes = numOfDataVolumes
 	}
 
 	if rawVal, exists := baseConfig.Params[SkipTeardownParamName]; exists && rawVal != "" {

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -46,6 +46,8 @@ const (
 	VMLiveMigrationKey                           = "vmLiveMigration"
 	VMHotplugVolumeKey                           = "vmHotplugVolume"
 	ConcurrentVMBootKey                          = "concurrentVMBoot"
+	VMSnapshotKey                                = "vmSnapshot"
+	VMRestoreKey                                 = "vmRestore"
 )
 
 type Reporter struct {
@@ -95,6 +97,8 @@ func FormatResults(checkupResults status.Results) map[string]string {
 		VMLiveMigrationKey:                           checkupResults.VMLiveMigration,
 		VMHotplugVolumeKey:                           checkupResults.VMHotplugVolume,
 		ConcurrentVMBootKey:                          checkupResults.ConcurrentVMBoot,
+		VMSnapshotKey:                                checkupResults.VMSnapshot,
+		VMRestoreKey:                                 checkupResults.VMRestore,
 	}
 
 	return formattedResults

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -105,6 +105,8 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.result.vmLiveMigration":                           checkupStatus.Results.VMLiveMigration,
 			"status.result.vmHotplugVolume":                           checkupStatus.Results.VMHotplugVolume,
 			"status.result.concurrentVMBoot":                          checkupStatus.Results.ConcurrentVMBoot,
+			"status.result.vmSnapshot":                                checkupStatus.Results.VMSnapshot,
+			"status.result.vmRestore":                                 checkupStatus.Results.VMRestore,
 		}
 		assert.Equal(t, expectedReportData, getCheckupData(t, fakeClient, testNamespace, testConfigMapName))
 	})

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -42,6 +42,8 @@ type Results struct {
 	VMLiveMigration                           string
 	VMHotplugVolume                           string
 	ConcurrentVMBoot                          string
+	VMSnapshot                                string
+	VMRestore                                 string
 }
 
 type Status struct {

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -190,7 +190,7 @@ func newCheckupRole() *rbacv1.Role {
 			},
 			{
 				APIGroups: []string{"subresources.kubevirt.io"},
-				Resources: []string{"virtualmachineinstances/addvolume", "virtualmachineinstances/removevolume"},
+				Resources: []string{"virtualmachines/stop", "virtualmachineinstances/addvolume", "virtualmachineinstances/removevolume"},
 				Verbs:     []string{"update"},
 			},
 			{
@@ -207,6 +207,11 @@ func newCheckupRole() *rbacv1.Role {
 				APIGroups: []string{""},
 				Resources: []string{"persistentvolumeclaims"},
 				Verbs:     []string{"delete"},
+			},
+			{
+				APIGroups: []string{"snapshot.kubevirt.io"},
+				Resources: []string{"virtualmachinesnapshots", "virtualmachinerestores"},
+				Verbs:     []string{"create", "get", "delete"},
 			},
 		},
 	}


### PR DESCRIPTION
 What this PR does :                                                                                                                                                  
                                                                                                                                                                      
 Adds VM snapshot and restore testing to the storage checkup. The checkup can now:                                                                                   
                                                                                                                                                                      
  1. Create a snapshot of a running VM (with multiple disks)                                                                                                          
  2. Validate the snapshot completed successfully                                                                                                                     
  3. Stop the VM and restore it from that snapshot                                                                                                                    
  4. Validate the restored VM has the expected volumes                                                                                                                
                                                                                                                                                                      
  Before this PR                                                                                                                                                      
                                                                                                                                                                      
  - The storage checkup covers VM boot, live migration, hotplug volumes, and concurrent boot but has no coverage for snapshot/restore operations.                   
  - VMs are created with only a single OS disk, which doesn't reflect real-world workloads where VMs typically have additional data disks.                            
                                                                                                                                                                      
  After this PR :                                                                                                                                                      

  Multi-disk VM support

  - VMs can be created with additional data disks via a new numOfDataVolumes ConfigMap parameter (default: 0, max: 10).                                                                                         
  - Data volumes are added to the VMI spec alongside the existing OS disk.

  Snapshot/restore client APIs                             

  The kubeVirtStorageClient interface is extended with:
  - Create / Get / Delete for VirtualMachineSnapshot
  - Get for VirtualMachineSnapshotContent (used to retrieve the content backing a snapshot for volume validation)
  - Create / Get / Delete for VirtualMachineRestore
  - Get / Update for VirtualMachine (needed to set RunStrategy: Halted before restoring)

  Real client implementations and test stubs are provided for all methods.

  Snapshot validation (checkVMSnapshot)                              

  Creates a snapshot named snapshot-<vm>, waits until ReadyToUse, then validates:                                                          
  - Phase is Succeeded                                               
  - Indications contain exactly [Online, GuestAgent]
  - Every VM template volume appears in IncludedVolumes (extra included volumes such as persistent TPM are allowed)
  - None of the expected template volumes appear in ExcludedVolumes

  Restore validation (checkVMRestore)

  Skips if no successful snapshot exists. Otherwise:
  - Stops the VM (sets RunStrategy: Halted)
  - Creates a restore named restore-<vm> and waits until Complete
  - Validates that the restored volumes cover all expected VM template volumes                                                             

  RBAC                                                               

  - virtualmachines verbs extended with get and update
  - New rules for virtualmachinesnapshots, virtualmachinerestores (create, get, delete) and virtualmachinesnapshotcontents (get)

  Reporting                                                          

  Results are reported via new vmSnapshot and vmRestore reporter keys.                                                                     

  Teardown

  The restore is deleted first, then the snapshot, after the test VM — ensuring correct cleanup ordering.

  Tests

  Unit tests cover snapshot validation (phase, indications, included/excluded volumes) and restore validation with both success and skip scenarios.                                                                                                                                   

  How to test                                                        

  Deploy the checkup with numOfDataVolumes: 2 (or higher) in the ConfigMap and verify the checkup reports vmSnapshot and vmRestore results in the output.    

References:

https://redhat.atlassian.net/browse/CNV-90395