### PR TITLE
 Upgrade golangci-lint to v2.12.2 for Go 1.26 compatibility

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Go mod tidy check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run the linter
         run: make lint
   unit-test:
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Unit tests
         run: make unit-test
   build:
@@ -40,6 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build checkup image
         run: make build

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ jobs:
       CHECKUP_IMAGE_TAG: ${{github.ref_name}}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to quay.io
         run:
           ${CONTAINER_ENGINE} login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,106 +1,93 @@
-# golangci configuration
+version: "2"
 
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 100
-    statements: 50
-  gci:
-    local-prefixes: github.com/kiagnose/kubevirt-storage-checkup
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-      - wrapperFunc
-    settings:
-      hugeParam:
-        sizeThreshold: 1024
-  gocyclo:
-    min-complexity: 15
-  goimports:
-    local-prefixes: github.com/kiagnose/kubevirt-storage-checkup
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
-  govet:
-    check-shadowing: true
-  lll:
-    line-length: 140
-  maligned:
-    suggest-new: true
-  misspell:
-    locale: US
-  nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/kiagnose/kubevirt-storage-checkup
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - exhaustive
     - funlen
     - gochecknoinits
-    - goconst
     - gocritic
     - gocyclo
-    - gofmt
     - goheader
-    - goimports
-    - gomnd
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
+    - mnd
     - nakedret
     - noctx
     - nolintlint
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-  # disabled beacuse of generics, tracker https://github.com/golangci/golangci-lint/issues/2649.
-  #  - rowserrcheck
-
-  # don't enable:
-  # - asciicheck
-  # - scopelint
-  # - gochecknoglobals
-  # - gocognit
-  # - godot
-  # - godox
-  # - goerr113
-  # - interfacer
-  # - maligned
-  # - nestif
-  # - prealloc
-  # - testpackage
-  # - revive
-  # - wsl
+  settings:
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 100
+      statements: 50
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - whyNoLint
+        - wrapperFunc
+        - uncheckedInlineErr
+      settings:
+        hugeParam:
+          sizeThreshold: 1024
+        rangeValCopy:
+          sizeThreshold: 1024
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    mnd:
+      checks:
+        - argument
+        - case
+        - condition
+        - return
+    nolintlint:
+      allow-unused: false
+      require-explanation: false
+      require-specific: false
+    staticcheck:
+      checks:
+        - all
+        - "-QF1001"
+        - "-QF1008"
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - std-error-handling

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GO_IMAGE_NAME := docker.io/library/golang
 GO_IMAGE_TAG := 1.26.0-bookworm
 
 LINTER_IMAGE_NAME := docker.io/golangci/golangci-lint
-LINTER_IMAGE_TAG := v1.50.1
+LINTER_IMAGE_TAG := v2.12.2
 
 PROJECT_WORKING_DIR := /go/src/github.com/kiagnose/kubevirt-storage-checkup
 


### PR DESCRIPTION
**What this PR does :**

Before this PR:

CI lint fails after the Go 1.26 bump because golangci-lint v1.50.1 (built with an older Go) refuses to analyze Go 1.26 code. 
Workflows also use actions/checkout@v3, which runs on the deprecated Node.js 16 runtime

After this PR:

  The project uses golangci-lint v2.12.2 in the Makefile, with .golangci.yaml migrated to the v2 config format. The gocritic "uncheckedInlineErr" check is disabled in the config so the idiomatic ignoreNotFound(err) pattern (aligned with kubevirt/CDI) is allowed without code changes. CI workflows are also bumped to actions/checkout@v4 (Node.js 20).    

Test plan

- [ ] make lint
- [ ] make unit-test
- [ ] make build
